### PR TITLE
jwebgpu: Use ByteBuffer to improve performance

### DIFF
--- a/gdx-webgpu2/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgImmediateModeRenderer.java
+++ b/gdx-webgpu2/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgImmediateModeRenderer.java
@@ -26,6 +26,9 @@ import com.monstrous.gdx.webgpu.application.WebGPUContext;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
 import com.monstrous.gdx.webgpu.graphics.WgTexture;
 import com.monstrous.gdx.webgpu.wrappers.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 
 
 /** Immediate mode rendering class for WebGPU. The renderer will allow you to specify vertices on the fly and provides a default
@@ -55,7 +58,8 @@ public class WgImmediateModeRenderer implements ImmediateModeRenderer {
 	private final PipelineSpecification pipelineSpec;
 	private WgTexture texture;
 	private WebGPURenderPass renderPass;
-	private final WGPUFloatBuffer vertexData;
+    private final ByteBuffer vertexBB;
+    private final FloatBuffer vertexData;
 	private WebGPUPipeline prevPipeline;
     private final WebGPUContext webgpu;
 
@@ -91,8 +95,8 @@ public class WgImmediateModeRenderer implements ImmediateModeRenderer {
 
 		createBuffers();
 
-		WGPUByteBuffer vertexBB = new WGPUByteBuffer(maxVertices * vertexSize*Float.BYTES);
-		vertexBB.order(WGPUByteOrder.LittleEndian); // webgpu expects little endian data
+        vertexBB = ByteBuffer.allocateDirect(maxVertices * vertexSize * Float.BYTES);
+		vertexBB.order(ByteOrder.LITTLE_ENDIAN); // webgpu expects little endian data
         vertexData = vertexBB.asFloatBuffer();  // float view on the byte buffer
 
 
@@ -199,7 +203,7 @@ public class WgImmediateModeRenderer implements ImmediateModeRenderer {
 
 		// copy vertex data to GPU vertex buffer
         //System.out.println("write buffer in imm mode rndr: size:"+numBytes+" byteData: "+vertexData.getByteBuffer().getLimit());
-        webgpu.queue.writeBuffer(vertexBuffer.getBuffer(), 0, vertexData.getByteBuffer());
+        webgpu.queue.writeBuffer(vertexBuffer.getBuffer(), 0, vertexBB, numBytes);
 
 		// Set vertex buffer while encoding the render pass
 		renderPass.setVertexBuffer( 0, vertexBuffer.getBuffer(), 0, numBytes);

--- a/gdx-webgpu2/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUBuffer.java
+++ b/gdx-webgpu2/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUBuffer.java
@@ -25,6 +25,7 @@ import com.github.xpenatan.webgpu.WGPUBufferUsage;
 import com.github.xpenatan.webgpu.WGPUByteBuffer;
 import com.monstrous.gdx.webgpu.application.WebGPUContext;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
+import java.nio.ByteBuffer;
 
 // Formerly WebGPUBuffer
 // Is there still an added value wrt WebGPUBuffer?
@@ -70,6 +71,12 @@ public class WebGPUBuffer implements Disposable {
         if(destOffset + data.getLimit() > bufferSize) throw new RuntimeException("Overflow in Buffer.write().");
         webgpu.queue.writeBuffer(buffer, destOffset, data);
         log(data.getLimit());
+    }
+
+    public void write(int destOffset, ByteBuffer data, int sizeInBytes){
+        if(destOffset + sizeInBytes > bufferSize) throw new RuntimeException("Overflow in Buffer.write().");
+        webgpu.queue.writeBuffer(buffer, destOffset, data, sizeInBytes);
+        log(data.limit());
     }
 
     @Override

--- a/gdx-webgpu2/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUIndexBuffer.java
+++ b/gdx-webgpu2/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUIndexBuffer.java
@@ -3,6 +3,10 @@ package com.monstrous.gdx.webgpu.wrappers;
 
 import com.badlogic.gdx.utils.Array;
 import com.github.xpenatan.webgpu.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
 
 public class WebGPUIndexBuffer extends WebGPUBuffer {
 
@@ -59,12 +63,13 @@ public class WebGPUIndexBuffer extends WebGPUBuffer {
         this.indexCount = indexCount;
         int indexBufferSize = align(indexCount * indexSizeInBytes);
 
-        WGPUByteBuffer byteBuffer = WGPUByteBuffer.obtain(indexBufferSize);
-        WGPUShortBuffer iData = byteBuffer.asShortBuffer();
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(indexBufferSize);
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        ShortBuffer iData = byteBuffer.asShortBuffer();
         for(int i = 0; i < indexCount; i++){
             iData.put(indices[i+srcOffset]);
         }
-        write(bufferOffset, byteBuffer);
+        write(bufferOffset, byteBuffer, indexBufferSize);
     }
 
     public void setIndices(int bufferOffset, int[] indices, int indexCount){
@@ -72,12 +77,13 @@ public class WebGPUIndexBuffer extends WebGPUBuffer {
         this.indexCount = indexCount;
         int indexBufferSize = align(indexCount * indexSizeInBytes);
 
-        WGPUByteBuffer byteBuffer = WGPUByteBuffer.obtain(indexBufferSize);
-        WGPUIntBuffer iData = byteBuffer.asIntBuffer();
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(indexBufferSize);
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        IntBuffer iData = byteBuffer.asIntBuffer();
         for(int i = 0; i < indexCount; i++){
             iData.put(indices[i]);
         }
-        write(bufferOffset, byteBuffer);
+        write(bufferOffset, byteBuffer, indexBufferSize);
     }
 
     public void setIndices(Array<Integer> indexValues) {
@@ -88,19 +94,20 @@ public class WebGPUIndexBuffer extends WebGPUBuffer {
         indexCount = indexValues.size;
         int indexBufferSize = align(indexCount * indexSizeInBytes);
 
-        WGPUByteBuffer byteBuffer = WGPUByteBuffer.obtain(indexBufferSize);
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(indexBufferSize);
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
         if (indexSizeInBytes == 2) {
-            WGPUShortBuffer iData = byteBuffer.asShortBuffer();
+            ShortBuffer iData = byteBuffer.asShortBuffer();
             for (int i = 0; i < indexCount; i++) {
                 iData.put(indexValues.get(i).shortValue());
             }
         } else if (indexSizeInBytes == 4) {
-            WGPUIntBuffer iData = byteBuffer.asIntBuffer();
+            IntBuffer iData = byteBuffer.asIntBuffer();
             for (int i = 0; i < indexCount; i++) {
                 iData.put(indexValues.get(i));
             }
         }
-        write(0, byteBuffer);
+        write(0, byteBuffer, indexBufferSize);
     }
 
     public void setIndices(WGPUByteBuffer byteData) {


### PR DESCRIPTION
This PR update some part of the code to use ByteBuffer. It gives better FPS compared to the custom solution.


Before: 
<img width="1263" height="942" alt="image" src="https://github.com/user-attachments/assets/ee4c719b-ac6b-42e5-bb0c-207ed55004ad" />

After:
<img width="1255" height="908" alt="image" src="https://github.com/user-attachments/assets/32d94a10-8ab6-43d6-9ec5-8abd5e843dac" />
