### PR TITLE
Reuse WGPU Instances and some improvements.

### DIFF
--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
@@ -1,7 +1,5 @@
 package com.monstrous.gdx.webgpu.application;
 
-
-
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Rectangle;
@@ -19,6 +17,7 @@ import com.github.xpenatan.webgpu.WGPUQueue;
 import com.github.xpenatan.webgpu.*;
 import com.monstrous.gdx.webgpu.graphics.WgTexture;
 import com.monstrous.gdx.webgpu.wrappers.GPUTimer;
+import com.monstrous.gdx.webgpu.wrappers.WebGPURenderPass;
 
 
 /** WebGPU graphics context and implementation of application life cycle. Used to initialize and terminate WebGPU and to render frames.
@@ -417,6 +416,7 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
 
         surface.release();
         command.dispose();
+        WebGPURenderPass.clearPool();
     }
 
 
@@ -440,8 +440,6 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
         return targetView;
     }
 
-
-
     /** Push a texture view to use for output, instead of the screen. */
     @Override
     public RenderOutputState pushTargetView(WgTexture texture, WgTexture depth) {
@@ -454,7 +452,6 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
         setViewportRectangle(0,0,texture.getWidth(), texture.getHeight());
         return state;
     }
-
 
     @Override
     public void popTargetView(RenderOutputState prevState) {

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgShaderProgram.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgShaderProgram.java
@@ -39,7 +39,7 @@ public class WgShaderProgram implements Disposable {
 
     public WgShaderProgram(FileHandle fileHandle, String prefix) {
         String source = fileHandle.readString();
-        compile(fileHandle.file().getName(), prefix+source);
+        compile(fileHandle.name(), prefix+source);
     }
 
     public WgShaderProgram(String name, String shaderSource, String prefix){

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgTexture.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgTexture.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.TextureData;
 import com.badlogic.gdx.graphics.glutils.PixmapTextureData;
+import com.badlogic.gdx.utils.BufferUtils;
 import com.github.xpenatan.webgpu.*;
 import com.monstrous.gdx.webgpu.application.WebGPUContext;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
@@ -434,8 +435,17 @@ public class WgTexture extends Texture {
             mipLevelWidth /= 2;
             mipLevelHeight /= 2;
 
+            if(prev != pixelPtr) {
+                BufferUtils.disposeUnsafeByteBuffer(prev);
+            }
             prev = next;
-            next = ByteBuffer.allocateDirect( mipLevelWidth * mipLevelHeight * 4);
+            next = BufferUtils.newUnsafeByteBuffer( mipLevelWidth * mipLevelHeight * 4);
+        }
+        if(prev != pixelPtr) {
+            BufferUtils.disposeUnsafeByteBuffer(prev);
+        }
+        if(next != pixelPtr) {
+            BufferUtils.disposeUnsafeByteBuffer(next);
         }
     }
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgImmediateModeRenderer.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgImmediateModeRenderer.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.glutils.ImmediateModeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.utils.BufferUtils;
 import com.github.xpenatan.webgpu.*;
 import com.monstrous.gdx.webgpu.application.WebGPUContext;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
@@ -95,7 +96,7 @@ public class WgImmediateModeRenderer implements ImmediateModeRenderer {
 
 		createBuffers();
 
-        vertexByteBuffer = ByteBuffer.allocateDirect(maxVertices * vertexSize * Float.BYTES);
+        vertexByteBuffer = BufferUtils.newUnsafeByteBuffer(maxVertices * vertexSize * Float.BYTES);
 		vertexByteBuffer.order(ByteOrder.LITTLE_ENDIAN); // webgpu expects little endian data
         vertexFloatBuffer = vertexByteBuffer.asFloatBuffer();  // float view on the byte buffer
 
@@ -362,5 +363,6 @@ public class WgImmediateModeRenderer implements ImmediateModeRenderer {
 		uniformBuffer.dispose();
 		bindGroupLayout.dispose();
 		pipelineLayout.dispose();
+        BufferUtils.disposeUnsafeByteBuffer(vertexByteBuffer);
 	}
 }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/RenderPassBuilder.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/RenderPassBuilder.java
@@ -174,12 +174,12 @@ public class RenderPassBuilder {
             renderPassDescriptor.setTimestampWrites(query);
         }
 
-        WGPURenderPassEncoder renderPass = new WGPURenderPassEncoder();
-        webgpu.encoder.beginRenderPass(renderPassDescriptor, renderPass);
 
-        WebGPURenderPass pass = new WebGPURenderPass(renderPass, passType, colorFormat, depthTexture.getFormat(), sampleCount,
-                outTexture == null ? Gdx.graphics.getWidth() : outTexture.getWidth(),
-                outTexture == null ? Gdx.graphics.getHeight() : outTexture.getHeight());
+        WebGPURenderPass pass = WebGPURenderPass.obtain();
+
+        pass.begin(webgpu.encoder, renderPassDescriptor, passType, colorFormat, depthTexture.getFormat(), sampleCount,
+            outTexture == null ? Gdx.graphics.getWidth() : outTexture.getWidth(),
+            outTexture == null ? Gdx.graphics.getHeight() : outTexture.getHeight());
 
         // todo may change over time
         Rectangle view = webgpu.getViewportRectangle();

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUUniformBuffer.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUUniformBuffer.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.Vector4;
+import com.badlogic.gdx.utils.BufferUtils;
 import com.github.xpenatan.webgpu.WGPUBufferUsage;
 import com.monstrous.gdx.webgpu.application.WebGPUContext;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
@@ -91,7 +92,7 @@ public class WebGPUUniformBuffer extends WebGPUBuffer {
         dirty = false;
 
         // working buffer in native memory to use as input to WriteBuffer
-        dataBuf = ByteBuffer.allocateDirect(contentSize);
+        dataBuf = BufferUtils.newUnsafeByteBuffer(contentSize);
         dataBuf.order(ByteOrder.LITTLE_ENDIAN);
         floatData = dataBuf.asFloatBuffer();
     }
@@ -197,5 +198,9 @@ public class WebGPUUniformBuffer extends WebGPUBuffer {
         dirty = true;
     }
 
-
+    @Override
+    public void dispose() {
+        BufferUtils.disposeUnsafeByteBuffer(dataBuf);
+        super.dispose();
+    }
 }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUVertexBuffer.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUVertexBuffer.java
@@ -1,6 +1,7 @@
 package com.monstrous.gdx.webgpu.wrappers;
 
 
+import com.badlogic.gdx.utils.BufferUtils;
 import com.github.xpenatan.webgpu.WGPUBufferUsage;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -23,7 +24,7 @@ public class WebGPUVertexBuffer extends WebGPUBuffer {
         // Create vertex buffer
         int size = vertexData.length * Float.BYTES;
         if(size > getSize()) throw new IllegalArgumentException("VertexBuffer.setVertices: data set too large.");
-        ByteBuffer dataBuf = ByteBuffer.allocateDirect(size);
+        ByteBuffer dataBuf = BufferUtils.newUnsafeByteBuffer(size);
         dataBuf.order(ByteOrder.LITTLE_ENDIAN);
         FloatBuffer floatBuf = dataBuf.asFloatBuffer();
         for(float f : vertexData)
@@ -36,7 +37,7 @@ public class WebGPUVertexBuffer extends WebGPUBuffer {
         int size = floats.size()*Float.BYTES;
         if(size > getSize()) throw new IllegalArgumentException("VertexBuffer.setVertices: data set too large.");
 
-        ByteBuffer dataBuf = ByteBuffer.allocateDirect(size);
+        ByteBuffer dataBuf = BufferUtils.newUnsafeByteBuffer(size);
         dataBuf.order(ByteOrder.LITTLE_ENDIAN);
         FloatBuffer floatBuf = dataBuf.asFloatBuffer();
         for (int i = 0; i < floats.size(); i++) {
@@ -44,6 +45,8 @@ public class WebGPUVertexBuffer extends WebGPUBuffer {
         }
         // Upload geometry data to the buffer
         write(0, dataBuf, size);
+
+        BufferUtils.disposeUnsafeByteBuffer(dataBuf);
     }
 
     public void setVertices(ByteBuffer byteData, int targetOffset, int sizeInBytes) {

--- a/tests/gdx-tests-teavm/src/main/java/com/monstrous/gdx/tests/webgpu/BuildTeaVM.java
+++ b/tests/gdx-tests-teavm/src/main/java/com/monstrous/gdx/tests/webgpu/BuildTeaVM.java
@@ -23,11 +23,9 @@ public class BuildTeaVM {
 
         TeaVMTool tool = TeaBuilder.config(teaBuildConfiguration);
         tool.setObfuscated(false);
-        tool.setTargetType(TeaVMTargetType.WEBASSEMBLY_GC);
-//        tool.setOptimizationLevel(TeaVMOptimizationLevel.ADVANCED);
+        tool.setTargetType(TeaVMTargetType.JAVASCRIPT);
+        tool.setOptimizationLevel(TeaVMOptimizationLevel.ADVANCED);
         tool.setMainClass(TeaVMTestLauncher.class.getName());
-//        int size = 64 * (1 << 20);
-//        tool.setMaxDirectBuffersSize(size);
         TeaBuilder.build(tool);
     }
 }

--- a/tests/gdx-tests-teavm/src/main/java/com/monstrous/gdx/tests/webgpu/BuildTeaVM.java
+++ b/tests/gdx-tests-teavm/src/main/java/com/monstrous/gdx/tests/webgpu/BuildTeaVM.java
@@ -23,7 +23,7 @@ public class BuildTeaVM {
 
         TeaVMTool tool = TeaBuilder.config(teaBuildConfiguration);
         tool.setObfuscated(false);
-        tool.setTargetType(TeaVMTargetType.JAVASCRIPT);
+        tool.setTargetType(TeaVMTargetType.WEBASSEMBLY_GC);
         tool.setOptimizationLevel(TeaVMOptimizationLevel.ADVANCED);
         tool.setMainClass(TeaVMTestLauncher.class.getName());
         TeaBuilder.build(tool);

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
@@ -350,6 +350,7 @@ public class ComputeMoldSlime extends GdxTest {
             pm.setColor(Color.BLACK);
             pm.fill();
             texture1.load(pm.getPixels(), 0);
+            pm.dispose();
         }
 
         step(Gdx.graphics.getDeltaTime());

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
@@ -55,6 +55,7 @@ public class ComputeMoldSlime extends GdxTest {
     private WGPUQueue queue;
     private WebGPUUniformBuffer uniforms;
     private WebGPUBuffer agents;
+    private WGPUComputePassEncoder pass;
     private Config config;
     private Viewport viewport;
     private WgStage stage;
@@ -105,7 +106,7 @@ public class ComputeMoldSlime extends GdxTest {
 
     private void initSim(int width, int height){
 
-
+        pass = new WGPUComputePassEncoder();
         WGPUTextureUsage textureUsage = WGPUTextureUsage.TextureBinding.or( WGPUTextureUsage.StorageBinding).or( WGPUTextureUsage.CopyDst).or( WGPUTextureUsage.CopySrc);
 
         //public WgTexture(String label, int width, int height, int mipLevelCount, int textureUsage, WGPUTextureFormat format, int numSamples )
@@ -194,7 +195,6 @@ public class ComputeMoldSlime extends GdxTest {
         encoderDesc.setLabel("Command Encoder");
         webgpu.device.createCommandEncoder(encoderDesc, encoder);
 
-        WGPUComputePassEncoder pass = new WGPUComputePassEncoder();
         WGPUComputePassDescriptor passDescriptor = WGPUComputePassDescriptor.obtain();
         passDescriptor.setNextInChain(null);
         passDescriptor.setTimestampWrites(null);
@@ -268,7 +268,6 @@ public class ComputeMoldSlime extends GdxTest {
         encoder.release();
         encoder.dispose();
         pass.release();
-        pass.dispose();
     }
 
 
@@ -320,6 +319,9 @@ public class ComputeMoldSlime extends GdxTest {
 
     @Override
     public void render(){
+//        int allocatedBytesUnsafe = BufferUtils.getAllocatedBytesUnsafe();
+//        System.out.println("allocatedBytesUnsafe: " + allocatedBytesUnsafe);
+
         if(Gdx.input.isKeyPressed(Input.Keys.ESCAPE)){
             Gdx.app.exit();
             return;
@@ -385,6 +387,7 @@ public class ComputeMoldSlime extends GdxTest {
         exitSim();
         batch.dispose();
         font.dispose();
+        pass.dispose();
     }
 
 

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
@@ -117,6 +117,7 @@ public class ComputeMoldSlime extends GdxTest {
         pm.setColor(Color.BLACK);
         pm.fill();
         texture1.load(pm.getPixels(), 0);
+        pm.dispose();
 
         // Create input and output textures
 

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
@@ -319,9 +319,6 @@ public class ComputeMoldSlime extends GdxTest {
 
     @Override
     public void render(){
-//        int allocatedBytesUnsafe = BufferUtils.getAllocatedBytesUnsafe();
-//        System.out.println("allocatedBytesUnsafe: " + allocatedBytesUnsafe);
-
         if(Gdx.input.isKeyPressed(Input.Keys.ESCAPE)){
             Gdx.app.exit();
             return;

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestCompute.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestCompute.java
@@ -3,6 +3,7 @@ package com.monstrous.gdx.tests.webgpu;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.utils.BufferUtils;
 import com.github.xpenatan.webgpu.*;
 import com.monstrous.gdx.tests.webgpu.utils.GdxTest;
 import com.monstrous.gdx.webgpu.application.WebGPUContext;
@@ -43,7 +44,7 @@ public class TestCompute extends GdxTest {
         WgGraphics gfx = (WgGraphics) Gdx.graphics;
         webgpu = gfx.getContext();
 
-        buf = ByteBuffer.allocateDirect(BUFFER_SIZE);
+        buf = BufferUtils.newUnsafeByteBuffer(BUFFER_SIZE);
         buf.order(ByteOrder.LITTLE_ENDIAN);
 
         // do the compute pass once on start up
@@ -194,6 +195,7 @@ public class TestCompute extends GdxTest {
         // cleanup
         batch.dispose();
         font.dispose();
+        BufferUtils.disposeUnsafeByteBuffer(buf);
     }
 
     @Override


### PR DESCRIPTION
This PR improve instance creation by pooling some of the Java objects to reduce memory leak.  Making zero instance per frame will improve performance. 

I left WGPUTextureView in WebGPUApplication because its a bit tricky to understand how it works. There is a pushTargetView and popTargetView method that changes the targetView object. Not sure how reusing will work here.

* Updated ByteBuffer creation to use BufferUtils.newUnsafeByteBuffer and BufferUtils.disposeUnsafeByteBuffer.  In TeaVM, it will dispose the bytebuffer with WASM option.
* Need to make sure the BufferUtils.disposes is correct in WgTexture.java
* Changed the GPUTimer to create a single callback instead of multiple instance
* Update RenderPassBuilder to pool WebGPURenderPass instance.
* Reusing WGPUComputePassEncoder in ComputeMoldSlime.java


<img width="1877" height="1213" alt="image" src="https://github.com/user-attachments/assets/d0cce4dc-30bc-4142-8b44-89590768dca7" />