### PR TITLE
Fix the render draw function to check for indices and add default WgModel constructor

### DIFF
--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgMesh.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgMesh.java
@@ -114,7 +114,7 @@ public class WgMesh extends Mesh {
         // bind vertices
         ((WgVertexBuffer)vertices).bind(renderPass);
 
-        if( getIndexData() != null) {   // is it an indexed mesh?
+        if( getIndexData().getNumIndices() > 0) {   // is it an indexed mesh?
             ((WgIndexBuffer)getIndexData()).bind(renderPass);// bind indices
             renderPass.drawIndexed(size, numInstances, offset, 0, firstInstance);
         } else {

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/WgModel.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/WgModel.java
@@ -48,6 +48,9 @@ import java.nio.ShortBuffer;
 public class WgModel extends Model {
 
 
+    public WgModel() {
+    }
+
 	public WgModel(ModelData data, TextureProvider textureProvider) {
 		super(data, textureProvider);
 	}


### PR DESCRIPTION

This PR contains two small changes:
* There is a default constructor in Model class so I added to WgModel also.
* Changed null mesh render checking to getNumIndices.  Mesh seems to this also.