### PR TITLE
Reuse WGPUTextureView

### DIFF
--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
@@ -38,6 +38,7 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
     private final float[] gpuTime = new float[GPUTimer.MAX_PASSES];
     private boolean mustResize = false;
     private int newWidth, newHeight;    // for resize
+    private WGPUTextureView textureViewOut;
 
     public static class Configuration {
         public int numSamples;
@@ -140,6 +141,7 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
                     command = new WGPUCommandBuffer();
                     gpuTimer = new GPUTimer(device, config.gpuTimingEnabled);
                     encoder = new WGPUCommandEncoder();
+                    textureViewOut = new WGPUTextureView();
 
                     System.out.println("Platform: " + WGPU.getPlatformType());
 
@@ -237,7 +239,9 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
         gpuTimer.fetchTimestamps();
 
         targetView.release();
-        targetView.dispose();
+        if(textureViewOut != targetView) {
+            targetView.dispose();
+        }
         targetView = null;
 
         if(WGPU.getPlatformType() != WGPUPlatformType.WGPU_Web) {
@@ -267,7 +271,6 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
 
 
     private WGPUTextureView getNextSurfaceTextureView() {
-        WGPUTextureView textureViewOut = new WGPUTextureView();
         WGPUSurfaceTexture surfaceTextureOut = WGPUSurfaceTexture.obtain();
         surface.getCurrentTexture(surfaceTextureOut);
 
@@ -413,6 +416,7 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
         device.destroy();
         device.dispose();
         gpuTimer.dispose();
+        textureViewOut.dispose();
 
         surface.release();
         command.dispose();


### PR DESCRIPTION
This PR reuse WGPUTextureView so its not created everyframe.

I added a dispose check if its not textureViewOut . I think this may not be needed, only if other methods that override targetView is called between getNextSurfaceTextureView and targetView.release();