### PR TITLE
Update jWebGPU to 0.1.3

### DIFF
--- a/backends/gdx-desktop-webgpu/src/main/java/com/monstrous/gdx/webgpu/backends/desktop/WgDesktopApplication.java
+++ b/backends/gdx-desktop-webgpu/src/main/java/com/monstrous/gdx/webgpu/backends/desktop/WgDesktopApplication.java
@@ -86,7 +86,7 @@ public class WgDesktopApplication implements Application {
             System.out.println("WebGPU Init Success: " + isSuccess);
             System.out.println("WebGPU implementation: "+config.backendWebGPU);
             if(isSuccess) {
-                WGPUInstance instance = WGPU.createInstance();
+                WGPUInstance instance = WGPU.setupInstance();
                 if(instance.isValid()) {
                     this.instance = instance;
                     wGPUInit = 1;

--- a/backends/gdx-desktop-webgpu/src/main/java/com/monstrous/gdx/webgpu/backends/desktop/WgDesktopGraphics.java
+++ b/backends/gdx-desktop-webgpu/src/main/java/com/monstrous/gdx/webgpu/backends/desktop/WgDesktopGraphics.java
@@ -24,19 +24,16 @@ import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.utils.Disposable;
 
-import com.github.xpenatan.webgpu.WGPUAdapter;
 import com.github.xpenatan.webgpu.WGPUInstance;
 import com.github.xpenatan.webgpu.WGPUSurface;
-import com.github.xpenatan.webgpu.WGPUSurfaceCapabilities;
+import com.github.xpenatan.webgpu.idl.IDLBase;
 import com.monstrous.gdx.webgpu.application.WebGPUApplication;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
 import com.monstrous.gdx.webgpu.graphics.utils.WgGL20;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.GLFW;
-import org.lwjgl.glfw.GLFWFramebufferSizeCallback;
 import org.lwjgl.glfw.GLFWNativeWin32;
-import org.lwjgl.system.Configuration;
 
 import java.nio.IntBuffer;
 import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WAYLAND;
@@ -144,7 +141,7 @@ public class WgDesktopGraphics implements WgGraphics, Disposable {
         System.out.println("os.name: "+osName);
         if(osName.contains("win")) {
             long display = GLFWNativeWin32.glfwGetWin32Window(windowHandle);
-            surface = instance.createWindowsSurface(display);
+            surface = instance.createWindowsSurface(IDLBase.createInstance().native_setVoid(display));
         }
         else if(osName.contains("linux")) {
             System.out.println("Platform: "+glfwGetPlatform());
@@ -152,17 +149,22 @@ public class WgDesktopGraphics implements WgGraphics, Disposable {
                 System.out.println("Wayland");
                 long display = glfwGetWaylandDisplay();
                 long surf = glfwGetWaylandWindow(windowHandle);
-                surface = instance.createLinuxSurface(true, surf, display);
+                IDLBase idlwindow = IDLBase.createInstance().native_setVoid(surf);
+                IDLBase idlDisplay = IDLBase.createInstance().native_setVoid(display);
+                surface = instance.createLinuxSurface(true, idlwindow, idlDisplay);
             }
             else {
                 System.out.println("X11");
                 long display = glfwGetX11Display();
                 long surf = glfwGetX11Window(windowHandle);
-                surface = instance.createLinuxSurface(false, surf, display);
+                IDLBase idlwindow = IDLBase.createInstance().native_setVoid(surf);
+                IDLBase idlDisplay = IDLBase.createInstance().native_setVoid(display);
+                surface = instance.createLinuxSurface(false, idlwindow, idlDisplay);
             }
         }
         else if(osName.contains("mac")) {
-            surface = instance.createMacSurface(windowHandle);
+            IDLBase idlHandle = IDLBase.createInstance().native_setVoid(windowHandle);
+            surface = instance.createMacSurface(idlHandle);
         }
         return surface;
     }

--- a/backends/gdx-teavm-webgpu/src/main/java/com/monstrous/gdx/webgpu/backends/teavm/WgTeaGraphics.java
+++ b/backends/gdx-teavm-webgpu/src/main/java/com/monstrous/gdx/webgpu/backends/teavm/WgTeaGraphics.java
@@ -66,7 +66,7 @@ public class WgTeaGraphics extends TeaGraphics implements WgGraphics {
             WebGPUContext.Backend.WEBGPU);
 
         System.out.println("Creating instance");
-        instance = WGPU.createInstance();
+        instance = WGPU.setupInstance();
         if(!instance.isValid()) {
             throw new RuntimeException("WebGPU: cannot get instance");
         }

--- a/docs/intro-to-webgpu.md
+++ b/docs/intro-to-webgpu.md
@@ -201,7 +201,7 @@ Note: step 3 to 5 are performed by the user's code in ApplicationListener.render
 
 	// create a color attachment
 	renderPassColorAttachment = WGPURenderPassColorAttachment.obtain();
-	renderPassColorAttachment.setNextInChain(null);
+	renderPassColorAttachment.setNextInChain(WGPUChainedStruct.NULL);
 
 	// clear to a grey background color
 	renderPassColorAttachment.setLoadOp(WGPULoadOp.Clear);
@@ -210,7 +210,7 @@ Note: step 3 to 5 are performed by the user's code in ApplicationListener.render
 
 	// attach to the targetView obtained earlier
 	renderPassColorAttachment.setView(targetView);
-	renderPassColorAttachment.setResolveTarget(null);
+	renderPassColorAttachment.setResolveTarget(WGPUTextureView.NULL);
 
 	// add the color attachment to the render pass descriptor
 	WGPUVectorRenderPassColorAttachment colorAttachments = WGPUVectorRenderPassColorAttachment.obtain();

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
@@ -220,7 +220,7 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
         gpuTimer.resolveTimeStamps(encoder);
 
         WGPUCommandBufferDescriptor cmdBufferDescriptor = WGPUCommandBufferDescriptor.obtain();
-        cmdBufferDescriptor.setNextInChain(null);
+        cmdBufferDescriptor.setNextInChain(WGPUChainedStruct.NULL);
         cmdBufferDescriptor.setLabel("Command buffer");
         encoder.finish(cmdBufferDescriptor, command);
         encoder.release();
@@ -372,7 +372,7 @@ public class WebGPUApplication extends WebGPUContext implements Disposable {
         config.setWidth(width);
         config.setHeight(height);
         config.setFormat(surfaceFormat);
-        config.setViewFormats(null);
+        config.setViewFormats(WGPUVectorTextureFormat.NULL);
         config.setUsage(WGPUTextureUsage.RenderAttachment);
         config.setDevice(device);
         config.setPresentMode(vsyncEnabled ? WGPUPresentMode.Fifo : WGPUPresentMode.Immediate);

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/Binder.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/Binder.java
@@ -241,7 +241,7 @@ public class Binder implements Disposable {
                 layouts.push_back(layout.getLayout());
 
             WGPUPipelineLayoutDescriptor pipelineLayoutDesc = WGPUPipelineLayoutDescriptor.obtain();
-            pipelineLayoutDesc.setNextInChain(null);
+            pipelineLayoutDesc.setNextInChain(WGPUChainedStruct.NULL);
             pipelineLayoutDesc.setLabel(label);
             pipelineLayoutDesc.setBindGroupLayouts(layouts);
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgShaderProgram.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgShaderProgram.java
@@ -19,6 +19,7 @@ package com.monstrous.gdx.webgpu.graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Disposable;
+import com.github.xpenatan.webgpu.WGPUChainedStruct;
 import com.github.xpenatan.webgpu.WGPUSType;
 import com.github.xpenatan.webgpu.WGPUShaderModule;
 import com.github.xpenatan.webgpu.WGPUShaderModuleDescriptor;
@@ -56,7 +57,7 @@ public class WgShaderProgram implements Disposable {
         shaderDesc.setLabel(name);
 
         WGPUShaderSourceWGSL shaderCodeDesc = WGPUShaderSourceWGSL.obtain();
-        shaderCodeDesc.getChain().setNext(null);
+        shaderCodeDesc.getChain().setNext(WGPUChainedStruct.NULL);
         shaderCodeDesc.getChain().setSType(WGPUSType.ShaderSourceWGSL);
         shaderCodeDesc.setCode(processedSource);
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgTexture.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgTexture.java
@@ -282,7 +282,7 @@ public class WgTexture extends Texture {
     public static WGPUTexture createTexture(String label, int width, int height, int mipLevelCount, WGPUTextureUsage textureUsage, WGPUTextureFormat format, int numLayers, int numSamples, WGPUTextureFormat viewFormat) {
         // Create the texture
         WGPUTextureDescriptor textureDesc = WGPUTextureDescriptor.obtain();
-        textureDesc.setNextInChain(null);
+        textureDesc.setNextInChain(WGPUChainedStruct.NULL);
         textureDesc.setLabel(label);
         textureDesc.setDimension(WGPUTextureDimension._2D);
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/environment/ibl/IBLGenerator.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/environment/ibl/IBLGenerator.java
@@ -171,7 +171,7 @@ public class IBLGenerator  {
                 mapBatch.end();
 
                 WGPUCommandBufferDescriptor cmdBufferDescriptor = WGPUCommandBufferDescriptor.obtain();
-                cmdBufferDescriptor.setNextInChain(null);
+                cmdBufferDescriptor.setNextInChain(WGPUChainedStruct.NULL);
                 cmdBufferDescriptor.setLabel("Command buffer");
                 WGPUCommandBuffer command = new WGPUCommandBuffer();
 
@@ -245,7 +245,7 @@ public class IBLGenerator  {
             mapBatch.end();
 
             WGPUCommandBufferDescriptor cmdBufferDescriptor = WGPUCommandBufferDescriptor.obtain();
-            cmdBufferDescriptor.setNextInChain(null);
+            cmdBufferDescriptor.setNextInChain(WGPUChainedStruct.NULL);
             cmdBufferDescriptor.setLabel("Command buffer");
             WGPUCommandBuffer command = new WGPUCommandBuffer();
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgImmediateModeRenderer.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgImmediateModeRenderer.java
@@ -343,7 +343,7 @@ public class WgImmediateModeRenderer implements ImmediateModeRenderer {
 
     private WGPUPipelineLayout createPipelineLayout(String label, WebGPUBindGroupLayout... bindGroupLayouts ) {
         WGPUPipelineLayoutDescriptor pipelineLayoutDesc = WGPUPipelineLayoutDescriptor.obtain();
-        pipelineLayoutDesc.setNextInChain(null);
+        pipelineLayoutDesc.setNextInChain(WGPUChainedStruct.NULL);
         pipelineLayoutDesc.setLabel(label);
         WGPUVectorBindGroupLayout layouts = WGPUVectorBindGroupLayout.obtain();
         for (int i = 0; i < bindGroupLayouts.length; i++)

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/GPUTimer.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/GPUTimer.java
@@ -51,7 +51,7 @@ public class GPUTimer implements Disposable {
 
         // Create timestamp queries
         WGPUQuerySetDescriptor querySetDescriptor =  WGPUQuerySetDescriptor.obtain();
-        querySetDescriptor.setNextInChain(null);
+        querySetDescriptor.setNextInChain(WGPUChainedStruct.NULL);
         querySetDescriptor.setLabel("Timestamp Query Set");
         querySetDescriptor.setType(WGPUQueryType.Timestamp);
         querySetDescriptor.setCount(2*MAX_PASSES); // start and end time

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/RenderPassBuilder.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/RenderPassBuilder.java
@@ -89,8 +89,8 @@ public class RenderPassBuilder {
         WGPUTextureFormat colorFormat = WGPUTextureFormat.Undefined;
 
         WGPURenderPassDescriptor renderPassDescriptor = WGPURenderPassDescriptor.obtain();
-        renderPassDescriptor.setNextInChain(null);
-        renderPassDescriptor.setOcclusionQuerySet(null);
+        renderPassDescriptor.setNextInChain(WGPUChainedStruct.NULL);
+        renderPassDescriptor.setOcclusionQuerySet(WGPUQuerySet.NULL);
         renderPassDescriptor.setLabel(name);
 
 
@@ -103,7 +103,7 @@ public class RenderPassBuilder {
             passType == RenderPassType.NO_DEPTH) {
 
             WGPURenderPassColorAttachment renderPassColorAttachment = WGPURenderPassColorAttachment.obtain();
-            renderPassColorAttachment.setNextInChain(null);
+            renderPassColorAttachment.setNextInChain(WGPUChainedStruct.NULL);
             renderPassColorAttachment.setStoreOp(WGPUStoreOp.Store);
 
             renderPassColorAttachment.setDepthSlice(-1);
@@ -128,13 +128,13 @@ public class RenderPassBuilder {
                     renderPassColorAttachment.setResolveTarget(webgpu.getTargetView());
                 } else {
                     renderPassColorAttachment.setView(webgpu.getTargetView());
-                    renderPassColorAttachment.setResolveTarget(null);
+                    renderPassColorAttachment.setResolveTarget(WGPUTextureView.NULL);
                 }
                 colorFormat = webgpu.getSurfaceFormat();
 
             } else {
                 renderPassColorAttachment.setView(outTexture.getTextureView());
-                renderPassColorAttachment.setResolveTarget(null);
+                renderPassColorAttachment.setResolveTarget(WGPUTextureView.NULL);
                 colorFormat = outTexture.getFormat();
                 sampleCount = 1;
             }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUBindGroup.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUBindGroup.java
@@ -69,7 +69,7 @@ public class WebGPUBindGroup implements Disposable {
         // Create a reusable bind group descriptor
         //
         bindGroupDescriptor = new WGPUBindGroupDescriptor();
-        bindGroupDescriptor.setNextInChain(null);
+        bindGroupDescriptor.setNextInChain(WGPUChainedStruct.NULL);
         bindGroupDescriptor.setLayout(layout.getLayout());
 
 
@@ -132,9 +132,9 @@ public class WebGPUBindGroup implements Disposable {
     }
 
     private void setDefault(WGPUBindGroupEntry entry){
-        entry.setBuffer(null);
-        entry.setSampler(null);
-        entry.setTextureView(null);
+        entry.setBuffer(WGPUBuffer.NULL);
+        entry.setSampler(WGPUSampler.NULL);
+        entry.setTextureView(WGPUTextureView.NULL);
     }
 
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUBindGroupLayout.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUBindGroupLayout.java
@@ -101,7 +101,7 @@ public class WebGPUBindGroupLayout implements Disposable {
      */
     private WGPUBindGroupLayoutEntry addBinding(int bindingId, WGPUShaderStage visibility ){
         WGPUBindGroupLayoutEntry bindingLayout =  new WGPUBindGroupLayoutEntry();
-        bindingLayout.setNextInChain(null);
+        bindingLayout.setNextInChain(WGPUChainedStruct.NULL);
         setDefaultLayout(bindingLayout);
         bindingLayout.setBinding(bindingId);
         bindingLayout.setVisibility(visibility);
@@ -111,7 +111,7 @@ public class WebGPUBindGroupLayout implements Disposable {
     public void end(){
         // Create a bind group layout
         WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc = WGPUBindGroupLayoutDescriptor.obtain();
-        bindGroupLayoutDesc.setNextInChain(null);
+        bindGroupLayoutDesc.setNextInChain(WGPUChainedStruct.NULL);
         bindGroupLayoutDesc.setLabel(label);
         WGPUVectorBindGroupLayoutEntry entryVector = WGPUVectorBindGroupLayoutEntry.obtain();
         for(WGPUBindGroupLayoutEntry entry : entries.values())
@@ -137,23 +137,23 @@ public class WebGPUBindGroupLayout implements Disposable {
 
 
     private void setDefaultLayout(WGPUBindGroupLayoutEntry bindingLayout) {
-        bindingLayout.setNextInChain(null);
+        bindingLayout.setNextInChain(WGPUChainedStruct.NULL);
 
 
 
-//        bindingLayout.getBuffer().setNextInChain(null);
+//        bindingLayout.getBuffer().setNextInChain(WGPUChainedStruct.NULL);
 //        bindingLayout.getBuffer().setType(WGPUBufferBindingType.Undefined);
 //        bindingLayout.getBuffer().setHasDynamicOffset(0);
 //
-//        bindingLayout.getSampler().setNextInChain(null);
+//        bindingLayout.getSampler().setNextInChain(WGPUChainedStruct.NULL);
 //        bindingLayout.getSampler().setType(WGPUSamplerBindingType.Undefined);
 //
-//        bindingLayout.getStorageTexture().setNextInChain(null);
+//        bindingLayout.getStorageTexture().setNextInChain(WGPUChainedStruct.NULL);
 //        bindingLayout.getStorageTexture().setAccess(WGPUStorageTextureAccess.Undefined);
 //        bindingLayout.getStorageTexture().setFormat(WGPUTextureFormat.Undefined);
 //        bindingLayout.getStorageTexture().setViewDimension(WGPUTextureViewDimension.Undefined);
 //
-//        bindingLayout.getTexture().setNextInChain(null);
+//        bindingLayout.getTexture().setNextInChain(WGPUChainedStruct.NULL);
 //        bindingLayout.getTexture().setMultisampled(0);
 //        bindingLayout.getTexture().setSampleType(WGPUTextureSampleType.Undefined);
 //        bindingLayout.getTexture().setViewDimension(WGPUTextureViewDimension.Undefined);

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUComputePipeline.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUComputePipeline.java
@@ -41,7 +41,7 @@ public class WebGPUComputePipeline implements Disposable {
 
         WGPUComputePipelineDescriptor pipelineDesc = WGPUComputePipelineDescriptor.obtain();
 
-        pipelineDesc.setNextInChain(null);
+        pipelineDesc.setNextInChain(WGPUChainedStruct.NULL);
 
         pipelineDesc.getCompute().setModule(shader.getShaderModule());
         pipelineDesc.getCompute().setEntryPoint(entryPoint);

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUPipeline.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUPipeline.java
@@ -50,7 +50,7 @@ public class WebGPUPipeline implements Disposable {
         WGPUVertexBufferLayout vertexBufferLayout = spec.vertexAttributes == null ? null : WebGPUVertexLayout.buildVertexBufferLayout(spec.vertexAttributes);
 
         WGPURenderPipelineDescriptor pipelineDesc = WGPURenderPipelineDescriptor.obtain();
-        pipelineDesc.setNextInChain(null);
+        pipelineDesc.setNextInChain(WGPUChainedStruct.NULL);
         pipelineDesc.setLabel(spec.name);
 
         WGPUVectorVertexBufferLayout bufferLayout = WGPUVectorVertexBufferLayout.obtain();
@@ -70,13 +70,13 @@ public class WebGPUPipeline implements Disposable {
 
         if (spec.colorFormat != WGPUTextureFormat.Undefined) {   // if there is a color attachment
             WGPUFragmentState fragmentState = WGPUFragmentState.obtain();
-            fragmentState.setNextInChain(null);
+            fragmentState.setNextInChain(WGPUChainedStruct.NULL);
             fragmentState.setModule(shader.getShaderModule());
             fragmentState.setEntryPoint(spec.fragmentShaderEntryPoint);
-            fragmentState.setConstants(null);
+            fragmentState.setConstants(WGPUVectorConstantEntry.NULL);
 
             // blending
-            WGPUBlendState blendState = null;
+            WGPUBlendState blendState = WGPUBlendState.NULL;
             if (spec.blendingEnabled) {
                 blendState = WGPUBlendState.obtain();
                 blendState.getColor().setSrcFactor(spec.blendSrcColor);
@@ -132,7 +132,7 @@ public class WebGPUPipeline implements Disposable {
 
             pipelineDesc.setDepthStencil(depthStencilState);
         } else {
-            pipelineDesc.setDepthStencil(null); // no depth or stencil buffer
+            pipelineDesc.setDepthStencil(WGPUDepthStencilState.NULL); // no depth or stencil buffer
         }
         pipelineDesc.getMultisample().setCount(spec.numSamples);
         pipelineDesc.getMultisample().setMask(-1);

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUPipelineLayout.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUPipelineLayout.java
@@ -18,6 +18,7 @@ package com.monstrous.gdx.webgpu.wrappers;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.Disposable;
+import com.github.xpenatan.webgpu.WGPUChainedStruct;
 import com.github.xpenatan.webgpu.WGPUPipelineLayout;
 import com.github.xpenatan.webgpu.WGPUPipelineLayoutDescriptor;
 import com.github.xpenatan.webgpu.WGPUVectorBindGroupLayout;
@@ -34,7 +35,7 @@ public class WebGPUPipelineLayout implements Disposable {
             layouts.push_back( bindGroupLayouts[i].getLayout());
 
         WGPUPipelineLayoutDescriptor pipelineLayoutDesc = WGPUPipelineLayoutDescriptor.obtain();
-        pipelineLayoutDesc.setNextInChain(null);
+        pipelineLayoutDesc.setNextInChain(WGPUChainedStruct.NULL);
         pipelineLayoutDesc.setLabel(label);
         pipelineLayoutDesc.setBindGroupLayouts(layouts);
         layout = new WGPUPipelineLayout();

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,8 @@ systemProp.com.android.tools.r8.disableHorizontalClassMerging=true
 
 java=11
 gdxWebGPU=0.1.2
-gdxTeaVMVersion=1.2.3
-jWebGPUVVersion=0.1.2
-teaVMVersion=0.12.1
+gdxTeaVMVersion=1.2.4
+jWebGPUVVersion=0.1.3
 enableGraalNative=false
 gdxVersion=1.13.5
 projectVersion=1.0.0

--- a/tests/gdx-tests-desktop/src/com/monstrous/gdx/tests/webgpu/Launcher.java
+++ b/tests/gdx-tests-desktop/src/com/monstrous/gdx/tests/webgpu/Launcher.java
@@ -13,7 +13,7 @@ public class Launcher {
         WgDesktopApplicationConfiguration config = new WgDesktopApplicationConfiguration();
         config.setWindowedMode(800, 480);
         config.setTitle("WebGPU");
-        config.backendWebGPU = JWebGPUBackend.DAWN;  // WGPU or DAWN
+        config.backendWebGPU = JWebGPUBackend.WGPU;  // WGPU or DAWN
         config.backend = WebGPUContext.Backend.DEFAULT; // Vulkan, DX12, etc.
 
         config.enableGPUtiming = false;

--- a/tests/gdx-tests-teavm/build.gradle.kts
+++ b/tests/gdx-tests-teavm/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     implementation("com.badlogicgames.gdx:gdx:$gdxVersion")
     implementation("com.github.xpenatan.gdx-teavm:backend-teavm:$gdxTeaVMVersion")
+    implementation("com.github.xpenatan.gdx-teavm:backend-teavm:$gdxTeaVMVersion:sources")
 
     //implementation(project(":tests:gdx-tests-webgpu2")) // module deleted
     implementation(project(":gdx-webgpu"))

--- a/tests/gdx-tests-teavm/src/main/java/com/monstrous/gdx/tests/webgpu/BuildTeaVM.java
+++ b/tests/gdx-tests-teavm/src/main/java/com/monstrous/gdx/tests/webgpu/BuildTeaVM.java
@@ -3,11 +3,14 @@ package com.monstrous.gdx.tests.webgpu;
 import com.github.xpenatan.gdx.backends.teavm.config.AssetFileHandle;
 import com.github.xpenatan.gdx.backends.teavm.config.TeaBuildConfiguration;
 import com.github.xpenatan.gdx.backends.teavm.config.TeaBuilder;
+import com.github.xpenatan.gdx.backends.teavm.config.TeaTargetType;
 import com.github.xpenatan.gdx.backends.teavm.config.plugins.TeaReflectionSupplier;
 import java.io.File;
 import java.io.IOException;
+import org.teavm.tooling.TeaVMSourceFilePolicy;
 import org.teavm.tooling.TeaVMTargetType;
 import org.teavm.tooling.TeaVMTool;
+import org.teavm.tooling.sources.DirectorySourceFileProvider;
 import org.teavm.vm.TeaVMOptimizationLevel;
 
 public class BuildTeaVM {
@@ -20,11 +23,19 @@ public class BuildTeaVM {
         teaBuildConfiguration.assetsPath.add(new AssetFileHandle("../assets"));
         teaBuildConfiguration.shouldGenerateAssetFile = true;
         teaBuildConfiguration.webappPath = new File("build/dist").getCanonicalPath();
+        teaBuildConfiguration.targetType = TeaTargetType.JAVASCRIPT;
+        TeaBuilder.config(teaBuildConfiguration);
 
-        TeaVMTool tool = TeaBuilder.config(teaBuildConfiguration);
-        tool.setObfuscated(true);
-        tool.setTargetType(TeaVMTargetType.JAVASCRIPT);
-        tool.setOptimizationLevel(TeaVMOptimizationLevel.ADVANCED);
+        TeaVMTool tool = new TeaVMTool();
+
+        tool.addSourceFileProvider(new DirectorySourceFileProvider(new File("../gdx-webgpu-tests/src/")));
+        tool.addSourceFileProvider(new DirectorySourceFileProvider(new File("../../gdx-webgpu/src/main/java")));
+        tool.setDebugInformationGenerated(true);
+        tool.setSourceMapsFileGenerated(true);
+        tool.setSourceFilePolicy(TeaVMSourceFilePolicy.COPY);
+
+        tool.setObfuscated(false);
+        tool.setOptimizationLevel(TeaVMOptimizationLevel.SIMPLE);
         int bufferSizeMB = 64;
         tool.setMaxDirectBuffersSize(bufferSizeMB * 1024 * 1024);
         tool.setMainClass(TeaVMTestLauncher.class.getName());

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/ComputeMoldSlime.java
@@ -197,15 +197,15 @@ public class ComputeMoldSlime extends GdxTest {
         webgpu.device.createCommandEncoder(encoderDesc, encoder);
 
         WGPUComputePassDescriptor passDescriptor = WGPUComputePassDescriptor.obtain();
-        passDescriptor.setNextInChain(null);
-        passDescriptor.setTimestampWrites(null);
+        passDescriptor.setNextInChain(WGPUChainedStruct.NULL);
+        passDescriptor.setTimestampWrites(WGPUComputePassTimestampWrites.NULL);
 
 
         // Step 1. move agents
         encoder.beginComputePass(passDescriptor, pass);
         // set pipeline & bind group 0
         pass.setPipeline(pipeline1.getPipeline());
-        pass.setBindGroup(0, bindGroupMove.getBindGroup(), null);
+        pass.setBindGroup(0, bindGroupMove.getBindGroup(), WGPUVectorInt.NULL);
 
         int invocationCountX = config.numAgents;    // nr of input values
 
@@ -220,7 +220,7 @@ public class ComputeMoldSlime extends GdxTest {
         encoder.beginComputePass(passDescriptor, pass);
         // set pipeline & bind group 0
         pass.setPipeline(pipeline2.getPipeline());
-        pass.setBindGroup(0, bindGroupEvap.getBindGroup(), null);
+        pass.setBindGroup(0, bindGroupEvap.getBindGroup(), WGPUVectorInt.NULL);
 
         invocationCountX = width;
         int invocationCountY = height;
@@ -239,7 +239,7 @@ public class ComputeMoldSlime extends GdxTest {
         encoder.beginComputePass(passDescriptor, pass);
         // set pipeline & bind group 0
         pass.setPipeline(pipeline3.getPipeline());
-        pass.setBindGroup(0, bindGroupBlur.getBindGroup(), null);
+        pass.setBindGroup(0, bindGroupBlur.getBindGroup(), WGPUVectorInt.NULL);
 
         invocationCountX = width;
         invocationCountY = height;

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestCompute.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestCompute.java
@@ -111,14 +111,14 @@ public class TestCompute extends GdxTest {
         // Create a compute pass
         WGPUComputePassEncoder pass = new WGPUComputePassEncoder();
         WGPUComputePassDescriptor passDescriptor = WGPUComputePassDescriptor.obtain();
-        passDescriptor.setNextInChain(null);
-        passDescriptor.setTimestampWrites(null);
+        passDescriptor.setNextInChain(WGPUChainedStruct.NULL);
+        passDescriptor.setTimestampWrites(WGPUComputePassTimestampWrites.NULL);
         encoder.beginComputePass(passDescriptor, pass);
 
 
             // set pipeline & bind group 0
             pass.setPipeline(pipeline.getPipeline());
-            pass.setBindGroup(0, bindGroup.getBindGroup(), null);
+            pass.setBindGroup(0, bindGroup.getBindGroup(), WGPUVectorInt.NULL);
 
             int workGroupSize = 32;
             int invocationCount = BUFFER_SIZE / Float.BYTES;    // nr of input values

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestMesh.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestMesh.java
@@ -28,7 +28,7 @@ public class TestMesh extends GdxTest {
             // create a render pipeline with the given shader code
 			PipelineSpecification pipelineSpec = new PipelineSpecification(vattr, getShaderSource());
 			pipelineSpec.name = "pipeline";
-			pipeline = new WebGPUPipeline((WGPUPipelineLayout) null, pipelineSpec);
+			pipeline = new WebGPUPipeline(WGPUPipelineLayout.NULL, pipelineSpec);
 
             // create a mesh for a square: 4 vertices and 6 indices (to make two triangles)
 			mesh = new WgMesh(true, 4, 6, vattr);

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestMeshBuilder.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestMeshBuilder.java
@@ -33,7 +33,7 @@ public class TestMeshBuilder extends GdxTest {
 
 			PipelineSpecification pipelineSpec = new PipelineSpecification(vattr, getShaderSource());
 			pipelineSpec.name = "pipeline";
-			pipeline = new WebGPUPipeline((WGPUPipelineLayout) null, pipelineSpec);
+			pipeline = new WebGPUPipeline(WGPUPipelineLayout.NULL, pipelineSpec);
 
 			// create a circular mesh part with the mesh builder
             WgMeshBuilder mb = new WgMeshBuilder();

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestMeshNoIndices.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TestMeshNoIndices.java
@@ -31,7 +31,7 @@ public class TestMeshNoIndices extends GdxTest {
             // create a render pipeline with the given shader code
 			PipelineSpecification pipelineSpec = new PipelineSpecification(vattr, getShaderSource());
 			pipelineSpec.name = "pipeline";
-			pipeline = new WebGPUPipeline((WGPUPipelineLayout) null, pipelineSpec);
+			pipeline = new WebGPUPipeline(WGPUPipelineLayout.NULL, pipelineSpec);
 
             // create a mesh for a square: 6 verts (to make two triangles)
 			mesh = new WgMesh(true, 6, 0, vattr);

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TextureArrayTest.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/TextureArrayTest.java
@@ -207,7 +207,7 @@ public class TextureArrayTest extends GdxTest {
 	}
 
     private String getShaderSource() {
-        return Gdx.files.classpath("data/wgsl/texture-array.wgsl").readString();
+        return Gdx.files.internal("data/wgsl/texture-array.wgsl").readString();
     }
 
 }


### PR DESCRIPTION
jWebGPU 0.1.3 features an updated jParser, where native methods no longer accept null objects, improving performance by removing the need for null checks in every method call. Additionally, all classes now include a static NULL instance, which can be used in place of the Java null keyword.  The binding no longer accept a long pointer value. It needs to be set in a IDLBase instance by using native_setVoid.

The TeaVM backend has also been upgraded to version 1.2.4.