### PR TITLE
Add Multi-Render Target support

### DIFF
--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUApplication.java
@@ -35,6 +35,13 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
     private boolean swapChainActive = false;
     private boolean disposed = false;
 
+    private WGPUTextureView[] defaultTargetViews;
+    private WGPUTextureFormat[] defaultSurfaceFormats;
+
+    // Pre-allocated scratch arrays used by the single-target pushTargetView overload to avoid per-call heap allocation
+    private final WGPUTextureView[] singleTargetViewScratch = new WGPUTextureView[1];
+    private final WGPUTextureFormat[] singleTargetFormatScratch = new WGPUTextureFormat[1];
+
     public static class Configuration {
         public int numSamples;
         public boolean vSyncEnabled;
@@ -82,10 +89,15 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
             if (formats.size() == 0) {
                 throw new RuntimeException("Adapter has no surface formats available");
             }
-            surfaceFormat = formats.get(0);
+            WGPUTextureFormat surfaceFormat = formats.get(0);
             // System.out.println("surfaceFormat: " + surfaceFormat);
 
             // allocate some objects we will reuse a lot
+            defaultTargetViews = new WGPUTextureView[1];
+            defaultSurfaceFormats = new WGPUTextureFormat[] {surfaceFormat};
+            targetViews = defaultTargetViews;
+            surfaceFormats = defaultSurfaceFormats;
+
             encoder = new WGPUCommandEncoder();
             command = new WGPUCommandBuffer();
             textureViewOut = new WGPUTextureView();
@@ -125,9 +137,15 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
     }
 
     public void renderFrame(ApplicationListener listener) {
-        targetView = getNextSurfaceTextureView();
+        WGPUTextureView targetView = getNextSurfaceTextureView();
+
         if (targetView == null)
             return;
+
+        defaultTargetViews[0] = targetView;
+        // defaultSurfaceFormats[0] is already set to surface format
+        targetViews = defaultTargetViews;
+        surfaceFormats = defaultSurfaceFormats;
 
         WGPUCommandEncoderDescriptor encoderDesc = WGPUCommandEncoderDescriptor.obtain();
         encoderDesc.setLabel("The Command Encoder");
@@ -248,7 +266,7 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
         if (config.numSamples > 1) {
             if (multiSamplingTexture != null)
                 multiSamplingTexture.dispose();
-            multiSamplingTexture = new WgTexture("multisampling", width, height, false, true, surfaceFormat,
+            multiSamplingTexture = new WgTexture("multisampling", width, height, false, true, defaultSurfaceFormats[0],
                     config.numSamples);
         }
 
@@ -303,7 +321,7 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
         WGPUSurfaceConfiguration config = WGPUSurfaceConfiguration.obtain();
         config.setWidth(width);
         config.setHeight(height);
-        config.setFormat(surfaceFormat);
+        config.setFormat(defaultSurfaceFormats[0]);
         config.setViewFormats(WGPUVectorTextureFormat.NULL);
         config.setUsage(WGPUTextureUsage.RenderAttachment);
         config.setDevice(device);
@@ -386,35 +404,48 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
 
     @Override
     public WGPUTextureFormat getSurfaceFormat() {
-        return surfaceFormat;
+        return surfaceFormats[0];
     }
 
     @Override
     public WGPUTextureView getTargetView() {
-        return targetView;
+        return targetViews[0];
+    }
+
+    @Override
+    public WGPUTextureView[] getTargetViews() {
+        return targetViews;
     }
 
     /** Push a texture view to use for output, instead of the screen. */
     @Override
-    public RenderOutputState pushTargetView(WGPUTextureView textureView, WGPUTextureFormat textureFormat, int width,
-            int height, WgTexture depthTex) {
-        RenderOutputState state = new RenderOutputState(targetView, surfaceFormat, depthTexture, getViewportRectangle(),
-                getSamples());
-        targetView = textureView;
-        surfaceFormat = textureFormat;
+    public RenderOutputState pushTargetView(RenderOutputState outState, WGPUTextureView textureView,
+            WGPUTextureFormat textureFormat, int width, int height, WgTexture depthTex) {
+        singleTargetViewScratch[0] = textureView;
+        singleTargetFormatScratch[0] = textureFormat;
+        return pushTargetView(outState, singleTargetViewScratch, singleTargetFormatScratch, width, height, depthTex);
+    }
+
+    @Override
+    public RenderOutputState pushTargetView(RenderOutputState outState, WGPUTextureView[] textureViews,
+            WGPUTextureFormat[] textureFormats, int width, int height, WgTexture depthTex) {
+        outState.set(targetViews, surfaceFormats, depthTexture, getViewportRectangle(), getSamples());
+        targetViews = textureViews;
+        surfaceFormats = textureFormats;
+
         config.numSamples = 1; // no antialiasing to texture output
         if (depthTex != null) {
             depthTexture = depthTex;
         }
-        setViewportRectangle(0, 0, width, height); // scissors too?
-        return state;
+        setViewportRectangle(0, 0, width, height);
+        return outState;
     }
 
     @Override
     public void popTargetView(RenderOutputState prevState) {
         setViewportRectangle(prevState.viewport);
-        targetView = prevState.targetView;
-        surfaceFormat = prevState.surfaceFormat;
+        targetViews = prevState.targetViews;
+        surfaceFormats = prevState.surfaceFormats;
         depthTexture = prevState.depthTexture;
         config.numSamples = prevState.numSamples;
     }
@@ -443,7 +474,7 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
     // }
 
     public boolean hasLinearOutput() {
-        switch (surfaceFormat) {
+        switch (surfaceFormats[0]) {
             case RGBA8UnormSrgb:
             case BGRA8UnormSrgb:
             case BC2RGBAUnormSrgb:
@@ -461,7 +492,7 @@ public class WebGPUApplication extends WebGPUContext implements WebGPUInitializa
                 // some more exotic formats to add...
                 return false;
             default:
-                Gdx.app.error("hasLinearOutput", "surfaceFormat not known: " + surfaceFormat);
+                Gdx.app.error("hasLinearOutput", "surfaceFormat not known: " + surfaceFormats[0]);
         }
         return true;
     }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUContext.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/application/WebGPUContext.java
@@ -11,18 +11,23 @@ public abstract class WebGPUContext {
     }
 
     static public class RenderOutputState {
-        WGPUTextureView targetView;
-        WGPUTextureFormat surfaceFormat;
+        WGPUTextureView[] targetViews;
+        WGPUTextureFormat[] surfaceFormats;
         WgTexture depthTexture;
-        Rectangle viewport;
+        Rectangle viewport = new Rectangle();
         int numSamples;
 
-        public RenderOutputState(WGPUTextureView targetView, WGPUTextureFormat surfaceFormat, WgTexture depthTexture,
+        /** Default constructor for pre-allocation and reuse. Use set() to fill the fields. */
+        public RenderOutputState() {
+        }
+
+        /** Fill this instance with the given state. Copies the viewport rectangle by value. */
+        public void set(WGPUTextureView[] targetViews, WGPUTextureFormat[] surfaceFormats, WgTexture depthTexture,
                 Rectangle viewport, int numSamples) {
-            this.targetView = targetView;
-            this.surfaceFormat = surfaceFormat;
+            this.targetViews = targetViews;
+            this.surfaceFormats = surfaceFormats;
             this.depthTexture = depthTexture;
-            this.viewport = new Rectangle(viewport);
+            this.viewport.set(viewport);
             this.numSamples = numSamples;
         }
     }
@@ -32,10 +37,15 @@ public abstract class WebGPUContext {
     public WGPUSurface surface;
     public WGPUQueue queue;
     public WGPUCommandEncoder encoder;
-    public WGPUTextureFormat surfaceFormat;
-    public WGPUTextureView targetView;
+    public WGPUTextureFormat[] surfaceFormats; // MRT support
+    public WGPUTextureView[] targetViews; // MRT support
     public WgTexture depthTexture;
     public int frameNumber;
+
+    // Pre-allocated scratch arrays for pushTargetView(WgTexture[]) to avoid per-call heap allocation.
+    // Sized to the actual number of textures; grown as needed so length always equals the valid element count.
+    private WGPUTextureView[] texturePushViewScratch = new WGPUTextureView[1];
+    private WGPUTextureFormat[] texturePushFormatScratch = new WGPUTextureFormat[1];
 
     abstract WGPUDevice getDevice();
 
@@ -47,14 +57,36 @@ public abstract class WebGPUContext {
 
     public abstract WGPUTextureView getTargetView();
 
+    public abstract WGPUTextureView[] getTargetViews(); // MRT
+
     /**
      * Use provided texture for output (must have usage RenderAttachment).
      *
-     * @return Render output state, to restore current output state with popTargetView().
+     * @param outState pre-allocated state object that will be filled with the current output state for later restore.
+     * @return outState (for convenience)
      */
     // public abstract RenderOutputState pushTargetView(WgTexture texture, WgTexture depthTexture);
-    public abstract RenderOutputState pushTargetView(WGPUTextureView textureView, WGPUTextureFormat textureFormat,
-            int width, int height, WgTexture depthTexture);
+    public abstract RenderOutputState pushTargetView(RenderOutputState outState, WGPUTextureView textureView,
+            WGPUTextureFormat textureFormat, int width, int height, WgTexture depthTexture);
+
+    public abstract RenderOutputState pushTargetView(RenderOutputState outState, WGPUTextureView[] textureViews,
+            WGPUTextureFormat[] textureFormats, int width, int height, WgTexture depthTexture);
+
+    public RenderOutputState pushTargetView(RenderOutputState outState, WgTexture[] textures, int width, int height,
+            WgTexture depthTexture) {
+        int count = textures.length;
+        // Reallocate only when count has grown — arrays are always exactly count elements,
+        // so that when WebGPUApplication assigns targetViews = textureViews the length is correct.
+        if (count != texturePushViewScratch.length) {
+            texturePushViewScratch = new WGPUTextureView[count];
+            texturePushFormatScratch = new WGPUTextureFormat[count];
+        }
+        for (int i = 0; i < count; i++) {
+            texturePushViewScratch[i] = textures[i].getTextureView();
+            texturePushFormatScratch[i] = textures[i].getFormat();
+        }
+        return pushTargetView(outState, texturePushViewScratch, texturePushFormatScratch, width, height, depthTexture);
+    }
 
     /**
      * Restore previous output target.

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgTexture.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/WgTexture.java
@@ -20,7 +20,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.TextureArrayData;
 import com.badlogic.gdx.graphics.TextureData;
 import com.badlogic.gdx.graphics.glutils.PixmapTextureData;
 import com.badlogic.gdx.utils.BufferUtils;
@@ -73,7 +72,6 @@ public class WgTexture extends Texture {
         this.data = new WgTextureData(width, height, useMipMaps, 0, 0);
         this.label = label;
         this.numSamples = numSamples;
-        this.format = format;
         create(label, useMipMaps, textureUsage, format, 1, numSamples, viewFormat);
     }
 
@@ -85,9 +83,9 @@ public class WgTexture extends Texture {
 
         this.numSamples = 1;
 
-        WGPUTextureFormat format = isColor ? WGPUTextureFormat.RGBA8UnormSrgb : WGPUTextureFormat.RGBA8Unorm;
+        WGPUTextureFormat fmt = isColor ? WGPUTextureFormat.RGBA8UnormSrgb : WGPUTextureFormat.RGBA8Unorm;
 
-        create(label, useMipMaps, textureUsage, format, numLayers, numSamples, null);
+        create(label, useMipMaps, textureUsage, fmt, numLayers, numSamples, null);
     }
 
     /*
@@ -153,16 +151,15 @@ public class WgTexture extends Texture {
         if (!data.isPrepared())
             data.prepare();
 
-        // mipLevelCount = data.useMipMaps() ? Math.max(1, bitWidth(Math.min(data.getWidth(), data.getHeight()))) : 1;
         numSamples = 1;
 
         // for color textures set format to Srgb so that on sampling it will be inverse gamma corrected to provide a
         // linear color value
         // for non-color texture, e.g. normal map, leave content as is.
-        format = isColor ? WGPUTextureFormat.RGBA8UnormSrgb : WGPUTextureFormat.RGBA8Unorm;
+        WGPUTextureFormat fmt = isColor ? WGPUTextureFormat.RGBA8UnormSrgb : WGPUTextureFormat.RGBA8Unorm;
 
         WGPUTextureUsage textureUsage = WGPUTextureUsage.TextureBinding.or(WGPUTextureUsage.CopyDst);
-        create(label, data.useMipMaps(), textureUsage, format, 1, numSamples, null);
+        create(label, data.useMipMaps(), textureUsage, fmt, 1, numSamples, null);
         Pixmap pixmap = data.consumePixmap();
         boolean mustDisposePixmap = data.disposePixmap();
 
@@ -188,15 +185,6 @@ public class WgTexture extends Texture {
         if (mustDisposePixmap)
             pixmap.dispose();
     }
-
-    // public void load(TextureArrayData data, String label){
-    // this.label = label;
-    // this.format = WGPUTextureFormat.RGBA8Unorm; // force format
-    // if (!data.isPrepared()) data.prepare();
-    //
-    // // this will create a WebGPU texture and upload the images
-    // data.consumeTextureArrayData();
-    // }
 
     @Override
     public int getWidth() {
@@ -267,32 +255,16 @@ public class WgTexture extends Texture {
 
         this.mipLevelCount = useMipMaps ? Math.max(1, bitWidth(Math.min(data.getWidth(), data.getHeight()))) : 1;
 
-        texture = createTexture(label, data.getWidth(), data.getHeight(), mipLevelCount, textureUsage, format,
+        this.texture = createTexture(label, data.getWidth(), data.getHeight(), mipLevelCount, textureUsage, format,
                 numLayers, numSamples, viewFormat);
         this.label = label;
         this.format = format;
-
-        // System.out.println("dimensions: "+textureDesc.getSize().getDepthOrArrayLayers());
 
         // Create the view of the texture manipulated by the rasterizer
         WGPUTextureViewDimension dimension = (numLayers == 1 ? WGPUTextureViewDimension._2D
                 : (numLayers == 6 ? WGPUTextureViewDimension.Cube : WGPUTextureViewDimension._2DArray));
 
-        // if this is a depth format, use only the depth aspect for the texture view
-        WGPUTextureAspect aspect;
-        switch (format) {
-            case Depth24Plus:
-            case Depth32Float:
-            case Depth24PlusStencil8:
-            case Depth16Unorm:
-            case Depth32FloatStencil8:
-                aspect = WGPUTextureAspect.DepthOnly;
-                break;
-            default:
-                aspect = WGPUTextureAspect.All;
-                break;
-        }
-        textureView = buildTextureView(dimension, format, 0, mipLevelCount, 0, numLayers);
+        this.textureView = buildTextureView(dimension, format, 0, mipLevelCount, 0, numLayers);
     }
 
     public static WGPUTexture createTexture(String label, int width, int height, int mipLevelCount,
@@ -313,18 +285,15 @@ public class WgTexture extends Texture {
         textureDesc.setUsage(textureUsage);
         WGPUVectorTextureFormat viewFormats = WGPUVectorTextureFormat.obtain();
 
-        // viewFormats.push_back(((WgGraphics)Gdx.graphics).getContext().surfaceFormat); // add surface format in any
-        // case
         if (viewFormat != null) {
             viewFormats.push_back(viewFormat);
         }
         textureDesc.setViewFormats(viewFormats);
 
-        WGPUTexture texture = new WGPUTexture();
+        WGPUTexture tex = new WGPUTexture();
         WebGPUContext webgpu = ((WgGraphics) Gdx.graphics).getContext();
-        // System.out.println("Create texture "+label);
-        webgpu.device.createTexture(textureDesc, texture);
-        return texture;
+        webgpu.device.createTexture(textureDesc, tex);
+        return tex;
     }
 
     public WGPUTextureView buildTextureView(WGPUTextureViewDimension dimension, WGPUTextureFormat format,
@@ -338,24 +307,20 @@ public class WgTexture extends Texture {
         textureViewDesc.setBaseMipLevel(baseMipLevel);
         textureViewDesc.setMipLevelCount(mipLevelCount);
         textureViewDesc.setDimension(dimension);
-        textureViewDesc.setFormat(format); // should this match surface format instead?
-        textureView = new WGPUTextureView();
-        texture.createView(textureViewDesc, textureView);
-        return textureView;
+        textureViewDesc.setFormat(format);
+        WGPUTextureView view = new WGPUTextureView();
+        texture.createView(textureViewDesc, view);
+        return view;
     }
 
     public WGPUSampler getSampler() {
         if (sampler == null) {
-            // System.out.println("create Sampler: "+label + " : "+uWrap);
-            // Create a sampler
-            //
             WGPUSamplerDescriptor samplerDesc = WGPUSamplerDescriptor.obtain();
             samplerDesc.setLabel("Standard texture sampler");
             samplerDesc.setAddressModeU(convertWrap(uWrap));
             samplerDesc.setAddressModeV(convertWrap(vWrap));
             samplerDesc.setAddressModeW(WGPUAddressMode.Repeat);
-            samplerDesc.setMagFilter(convertFilter(magFilter)); // default filter in LibGDX is nearest for min and mag
-                                                                // filter
+            samplerDesc.setMagFilter(convertFilter(magFilter));
             samplerDesc.setMinFilter(convertFilter(minFilter));
             samplerDesc.setMipmapFilter(WGPUMipmapFilterMode.Linear); // todo
 
@@ -371,7 +336,6 @@ public class WgTexture extends Texture {
 
     public WGPUSampler getDepthSampler() {
         if (depthSampler == null) {
-            // Create a sampler
             WGPUSamplerDescriptor samplerDesc = WGPUSamplerDescriptor.obtain();
             samplerDesc.setAddressModeU(WGPUAddressMode.ClampToEdge);
             samplerDesc.setAddressModeV(WGPUAddressMode.ClampToEdge);
@@ -477,7 +441,7 @@ public class WgTexture extends Texture {
     /**
      * Load pixel data into texture.
      *
-     * @param pixelPtr
+     * @param pixelPtr pixel data
      * @param layer which layer to load in case of a 3d texture, otherwise 0
      */
     public void load(ByteBuffer pixelPtr, int width, int height, int layer) {
@@ -501,7 +465,6 @@ public class WgTexture extends Texture {
             if (mipLevel != 0) {
 
                 // todo with compute shader
-                int offset = 0;
                 for (int y = 0; y < mipLevelHeight; y++) {
                     for (int x = 0; x < mipLevelWidth; x++) {
 
@@ -538,17 +501,11 @@ public class WgTexture extends Texture {
             if (prev != null && prev != pixelPtr) {
                 BufferUtils.disposeUnsafeByteBuffer(prev);
             }
-            // if(mipLevel == mipLevelCount-1)
-            // break;
             // todo we should be able to avoid one malloc/free
             prev = next;
             next = BufferUtils.newUnsafeByteBuffer(mipLevelWidth * mipLevelHeight * 4);
         }
 
-        // todo check this logic
-        // if(prev != pixelPtr) {
-        // BufferUtils.disposeUnsafeByteBuffer(prev);
-        // }
         if (next != pixelPtr) {
             BufferUtils.disposeUnsafeByteBuffer(next);
         }
@@ -556,7 +513,6 @@ public class WgTexture extends Texture {
 
     /**
      * Load image data into a specific layer and mip level
-     *
      */
     public void loadMipLevel(ByteBuffer data, int width, int height, int layer, int mipLevel) {
 
@@ -587,8 +543,6 @@ public class WgTexture extends Texture {
     // use at own risk
     public void load(ByteBuffer pixels) {
 
-        // Arguments telling which part of the texture we upload to
-        // (together with the last argument of writeTexture)
         WGPUTexelCopyTextureInfo destination = WGPUTexelCopyTextureInfo.obtain();
         destination.setTexture(texture);
         destination.setMipLevel(0);
@@ -641,16 +595,15 @@ public class WgTexture extends Texture {
 
     @Override
     public void dispose() {
-        // System.out.println("Dispose texture : "+label);
-
         if (texture != null) { // guard against double dispose
-            // System.out.println("Destroy texture " + label);
             if (sampler != null) {
                 sampler.release();
                 sampler.dispose();
             }
-            textureView.release();
-            textureView.dispose();
+            if (textureView != null) {
+                textureView.release();
+                textureView.dispose();
+            }
             texture.destroy();
             texture.dispose();
             texture = null;

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g2d/WgSpriteBatch.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g2d/WgSpriteBatch.java
@@ -447,9 +447,15 @@ public class WgSpriteBatch implements Batch {
 
     // create or reuse pipeline on demand to match the pipeline spec
     private void setPipeline(WebGPURenderPass pass) {
-        // Update pipeline spec to match the current render pass's format and sample count
-        // This is crucial when rendering to framebuffers with different formats than the screen
-        pipelineSpec.colorFormat = pass.getColorFormat();
+        // Update pipeline spec to match the current render pass's format and sample count.
+        // Clone the formats array — getColorFormats() returns the render pass's internal array,
+        // which could be mutated when the pooled pass is reused, corrupting the cached spec.
+        WGPUTextureFormat[] formats = pass.getColorFormats();
+        if (pipelineSpec.colorFormats == null || pipelineSpec.colorFormats.length != formats.length) {
+            pipelineSpec.colorFormats = formats.clone();
+        } else {
+            System.arraycopy(formats, 0, pipelineSpec.colorFormats, 0, formats.length);
+        }
         pipelineSpec.numSamples = pass.getSampleCount();
         pipelineSpec.invalidateHashCode();
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/WgModelBatch.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/WgModelBatch.java
@@ -67,6 +67,7 @@ public class WgModelBatch implements Disposable {
         public boolean usePBR; // use physics based rendering
         public MaterialsCache materials;
         public RenderPassType defaultPassType;
+        public String shaderSource;
 
         public Config() {
             this.maxInstances = 1024;

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/environment/ibl/IBLGenerator.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/environment/ibl/IBLGenerator.java
@@ -150,6 +150,9 @@ public class IBLGenerator {
         // disable gpu timing before we do lots of passes to avoid overflow
         boolean timerEnabled = webgpu.getGPUTimer().setEnabled(false);
 
+        // Pre-allocate once outside the loops to avoid per-mip-level allocation
+        WebGPUContext.RenderOutputState prevState = new WebGPUContext.RenderOutputState();
+
         for (int mipLevel = 0; mipLevel < numLevels; mipLevel++) {
 
             final WGPUTextureUsage textureUsage = WGPUTextureUsage.TextureBinding.or(WGPUTextureUsage.CopyDst)
@@ -179,8 +182,7 @@ public class IBLGenerator {
                 encoderDesc.setLabel("encoder");
                 webgpu.device.createCommandEncoder(encoderDesc, webgpu.encoder);
 
-                WebGPUContext.RenderOutputState prevState = webgpu.pushTargetView(colorTexture.getTextureView(), format,
-                        size, size, depthTexture);
+                webgpu.pushTargetView(prevState, colorTexture.getTextureView(), format, size, size, depthTexture);
 
                 mapBatch.begin(snapCam, Color.GREEN, true, 1);
                 mapBatch.render(instance, environment);
@@ -244,6 +246,7 @@ public class IBLGenerator {
         webgpu.setViewportRectangle(0, 0, size, size);
 
         boolean timerEnabled = webgpu.getGPUTimer().setEnabled(false);
+        WebGPUContext.RenderOutputState prevState = new WebGPUContext.RenderOutputState();
         for (int side = 0; side < 6; side++) {
             // point the camera at one of the cube sides
             snapCam.direction.set(directions[side]);
@@ -260,8 +263,7 @@ public class IBLGenerator {
             encoderDesc.setLabel("encoder");
             webgpu.device.createCommandEncoder(encoderDesc, webgpu.encoder);
 
-            WebGPUContext.RenderOutputState prevState = webgpu.pushTargetView(colorTexture.getTextureView(), format,
-                    size, size, depthTexture);
+            webgpu.pushTargetView(prevState, colorTexture.getTextureView(), format, size, size, depthTexture);
 
             mapBatch.begin(snapCam, Color.BLACK, true, 1);
             mapBatch.render(instance);

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/environment/ibl/IBLShader.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/environment/ibl/IBLShader.java
@@ -133,7 +133,7 @@ public class IBLShader extends WgShader implements Disposable {
         WgGraphics gfx = (WgGraphics) Gdx.graphics;
         WebGPUContext webgpu = gfx.getContext();
 
-        pipelineSpec.colorFormat = webgpu.surfaceFormat; // WGPUTextureFormat.BGRA8Unorm;
+        pipelineSpec.colorFormats = new WGPUTextureFormat[] {webgpu.getSurfaceFormat()};
 
         pipeline = new WebGPUPipeline(pipelineLayout, pipelineSpec);
     }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/shaders/WgDefaultShader.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/shaders/WgDefaultShader.java
@@ -379,15 +379,24 @@ public class WgDefaultShader extends WgShader implements Disposable {
 
         materials.start(); // indicate that no material is currently bound
 
-        // Update pipeline spec to match the current render pass's format and sample count
-        // This is crucial when rendering to framebuffers with different formats than the screen
-        pipelineSpec.colorFormat = renderPass.getColorFormat();
-        pipelineSpec.numSamples = renderPass.getSampleCount();
+        setPipeline(renderPass);
+    }
+
+    private void setPipeline(WebGPURenderPass pass) {
+        // Update pipeline spec to match the current render pass's format and sample count.
+        // Clone the formats array — getColorFormats() returns the render pass's internal array,
+        // which could be mutated when the pooled pass is reused, corrupting the cached spec.
+        WGPUTextureFormat[] formats = pass.getColorFormats();
+        if (pipelineSpec.colorFormats == null || pipelineSpec.colorFormats.length != formats.length) {
+            pipelineSpec.colorFormats = formats.clone();
+        } else {
+            System.arraycopy(formats, 0, pipelineSpec.colorFormats, 0, formats.length);
+        }
+        pipelineSpec.numSamples = pass.getSampleCount();
         pipelineSpec.invalidateHashCode();
 
-        // Get or create a pipeline that matches the current render target
         WebGPUPipeline pipeline = pipelineCache.findPipeline(pipelineLayout, pipelineSpec);
-        renderPass.setPipeline(pipeline);
+        pass.setPipeline(pipeline);
     }
 
     @Override
@@ -636,6 +645,9 @@ public class WgDefaultShader extends WgShader implements Disposable {
     // todo vertex attributes are hardcoded, should use conditional compilation.
 
     private String getDefaultShaderSource() {
+        if (config.shaderSource != null)
+            return config.shaderSource;
+
         if (defaultShader == null) {
             defaultShader = Gdx.files.classpath("shaders/modelbatch.wgsl").readString();
         }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/shaders/WgDepthShader.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/g3d/shaders/WgDepthShader.java
@@ -141,7 +141,7 @@ public class WgDepthShader extends WgShader {
         pipelineSpec.vertexLayout.setVertexAttributeLocation(ShaderProgram.BONEWEIGHT_ATTRIBUTE, 7);
 
         // Fragment shader entry point (null for normal depth rendering, "fs_main" for masking)
-        pipelineSpec.colorFormat = WGPUTextureFormat.Undefined; // No color output
+        pipelineSpec.colorFormats = null; // No color output
         pipelineSpec.fragmentShaderEntryPoint = fragmentEntryPoint;
         pipelineSpec.isDepthPass = true; // Mark this as a depth pass
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgFrameBuffer.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/graphics/utils/WgFrameBuffer.java
@@ -17,11 +17,9 @@ package com.monstrous.gdx.webgpu.graphics.utils;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.Disposable;
 import com.github.xpenatan.webgpu.WGPUTextureFormat;
 import com.github.xpenatan.webgpu.WGPUTextureUsage;
-import com.github.xpenatan.webgpu.WGPUTextureView;
 import com.monstrous.gdx.webgpu.application.WebGPUContext;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
 import com.monstrous.gdx.webgpu.graphics.WgTexture;
@@ -31,8 +29,10 @@ public class WgFrameBuffer implements Disposable {
 
     private final WebGPUContext webgpu;
     private final WgTexture colorTexture;
+    private final WgTexture[] colorTextures;
     private final WgTexture depthTexture;
-    private WebGPUContext.RenderOutputState prevState;
+    // Pre-allocated to avoid per-frame heap allocation in begin()
+    private final WebGPUContext.RenderOutputState prevState = new WebGPUContext.RenderOutputState();
 
     public WgFrameBuffer(int width, int height, boolean hasDepth) {
         this(WGPUTextureFormat.RGBA8UnormSrgb, width, height, hasDepth);
@@ -40,12 +40,23 @@ public class WgFrameBuffer implements Disposable {
 
     /** note: requires WGPUTextureFormat instead of Pixmap.Format. */
     public WgFrameBuffer(WGPUTextureFormat format, int width, int height, boolean hasDepth) {
+        this(new WGPUTextureFormat[] {format}, width, height, hasDepth);
+    }
+
+    public WgFrameBuffer(WGPUTextureFormat[] formats, int width, int height, boolean hasDepth) {
         WgGraphics gfx = (WgGraphics) Gdx.graphics;
         webgpu = gfx.getContext();
 
         final WGPUTextureUsage textureUsage = WGPUTextureUsage.TextureBinding.or(WGPUTextureUsage.CopyDst)
                 .or(WGPUTextureUsage.RenderAttachment).or(WGPUTextureUsage.CopySrc);
-        colorTexture = new WgTexture("fbo color", width, height, false, textureUsage, format, 1, format);
+
+        colorTextures = new WgTexture[formats.length];
+        for (int i = 0; i < formats.length; i++) {
+            colorTextures[i] = new WgTexture("fbo color " + i, width, height, false, textureUsage, formats[i], 1,
+                    formats[i]);
+        }
+        colorTexture = colorTextures[0];
+
         if (hasDepth)
             depthTexture = new WgTexture("fbo depth", width, height, false, textureUsage, WGPUTextureFormat.Depth24Plus,
                     1, WGPUTextureFormat.Depth24Plus);
@@ -54,8 +65,10 @@ public class WgFrameBuffer implements Disposable {
     }
 
     public void begin() {
-        prevState = webgpu.pushTargetView(colorTexture.getTextureView(), colorTexture.getFormat(),
-                colorTexture.getWidth(), colorTexture.getHeight(), depthTexture);
+        // WebGPUContext.pushTargetView(WgTexture[]) manages its own internal scratch arrays —
+        // no allocation occurs here whether this is a single-target or MRT framebuffer.
+        webgpu.pushTargetView(prevState, colorTextures, colorTexture.getWidth(), colorTexture.getHeight(),
+                depthTexture);
     }
 
     public void end() {
@@ -64,6 +77,10 @@ public class WgFrameBuffer implements Disposable {
 
     public Texture getColorBufferTexture() {
         return colorTexture;
+    }
+
+    public Texture getColorBufferTexture(int index) {
+        return colorTextures[index];
     }
 
     public Texture getDepthTexture() {
@@ -80,7 +97,9 @@ public class WgFrameBuffer implements Disposable {
 
     @Override
     public void dispose() {
-        colorTexture.dispose();
+        for (WgTexture tex : colorTextures) {
+            tex.dispose();
+        }
         if (depthTexture != null)
             depthTexture.dispose();
     }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/PipelineSpecification.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/PipelineSpecification.java
@@ -23,6 +23,7 @@ import com.github.xpenatan.webgpu.*;
 import com.monstrous.gdx.webgpu.application.WgGraphics;
 import com.monstrous.gdx.webgpu.graphics.WgShaderProgram;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 // todo Environment
@@ -46,6 +47,8 @@ public class PipelineSpecification {
     public boolean afterDepthPrepass;
     public int numSamples;
 
+    public WGPUTextureFormat[] colorFormats; // MRT support
+
     public boolean blendingEnabled;
     public WGPUBlendFactor blendSrcColor;
     public WGPUBlendFactor blendDstColor;
@@ -55,11 +58,11 @@ public class PipelineSpecification {
     public WGPUBlendOperation blendOpAlpha;
     public WGPUCullMode cullMode;
 
-    public WGPUTextureFormat colorFormat;
     public WGPUTextureFormat depthFormat;
     public int maxDirLights;
     public int maxPointLights;
     public boolean usePBR;
+    public String customPrefix; // To add extra defines e.g. for MRT
     private int hash;
     private boolean dirty; // does hash need to be recalculated?
 
@@ -80,7 +83,7 @@ public class PipelineSpecification {
         topology = WGPUPrimitiveTopology.TriangleList;
         isDepthPass = false;
         WgGraphics gfx = (WgGraphics) Gdx.graphics;
-        colorFormat = gfx.getContext().getSurfaceFormat();
+        colorFormats = new WGPUTextureFormat[] {gfx.getContext().getSurfaceFormat()};
         depthFormat = WGPUTextureFormat.Depth24Plus; // todo get from adapter?
         numSamples = gfx.getContext().getSamples(); // take from window
         isSkyBox = false;
@@ -131,7 +134,11 @@ public class PipelineSpecification {
         this.isSkyBox = spec.isSkyBox;
         this.afterDepthPrepass = spec.afterDepthPrepass;
 
-        this.colorFormat = spec.colorFormat;
+        if (spec.colorFormats != null)
+            this.colorFormats = spec.colorFormats.clone();
+        else
+            this.colorFormats = null;
+
         this.depthFormat = spec.depthFormat;
         this.numSamples = spec.numSamples;
         this.maxDirLights = spec.maxDirLights;
@@ -139,6 +146,7 @@ public class PipelineSpecification {
         this.usePBR = spec.usePBR;
         this.fragmentShaderEntryPoint = spec.fragmentShaderEntryPoint;
         this.vertexShaderEntryPoint = spec.vertexShaderEntryPoint;
+        this.customPrefix = spec.customPrefix;
         this.dirty = true;
     }
 
@@ -213,51 +221,34 @@ public class PipelineSpecification {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        return hash == ((PipelineSpecification) o).hash;
+        PipelineSpecification that = (PipelineSpecification) o;
+        return useDepthTest == that.useDepthTest && noDepthAttachment == that.noDepthAttachment
+                && isSkyBox == that.isSkyBox && isDepthPass == that.isDepthPass
+                && afterDepthPrepass == that.afterDepthPrepass && numSamples == that.numSamples
+                && blendingEnabled == that.blendingEnabled && Objects.equals(name, that.name)
+                && Objects.equals(vertexAttributes, that.vertexAttributes)
+                && Objects.equals(vertexLayout, that.vertexLayout) && vertexStepMode == that.vertexStepMode
+                && indexFormat == that.indexFormat && topology == that.topology
+                && Objects.equals(environment, that.environment) && Objects.equals(shaderSource, that.shaderSource)
+                && Objects.equals(vertexShaderEntryPoint, that.vertexShaderEntryPoint)
+                && Objects.equals(fragmentShaderEntryPoint, that.fragmentShaderEntryPoint)
+                && Objects.equals(shader, that.shader) && Arrays.equals(colorFormats, that.colorFormats)
+                && blendSrcColor == that.blendSrcColor && blendDstColor == that.blendDstColor
+                && blendOpColor == that.blendOpColor && blendSrcAlpha == that.blendSrcAlpha
+                && blendDstAlpha == that.blendDstAlpha && blendOpAlpha == that.blendOpAlpha && cullMode == that.cullMode
+                && depthFormat == that.depthFormat && maxDirLights == that.maxDirLights
+                && maxPointLights == that.maxPointLights && usePBR == that.usePBR
+                && Objects.equals(customPrefix, that.customPrefix);
     }
 
     @Override
     public int hashCode() {
-        if (dirty)
-            recalcHash();
-        return hash;
+        int result = Objects.hash(name, vertexAttributes, vertexLayout, vertexStepMode, indexFormat, topology,
+                environment, shaderSource, vertexShaderEntryPoint, fragmentShaderEntryPoint, shader, useDepthTest,
+                noDepthAttachment, isSkyBox, isDepthPass, afterDepthPrepass, numSamples, blendingEnabled, blendSrcColor,
+                blendDstColor, blendOpColor, blendSrcAlpha, blendDstAlpha, blendOpAlpha, cullMode, depthFormat,
+                maxDirLights, maxPointLights, usePBR, customPrefix);
+        result = 31 * result + Arrays.hashCode(colorFormats);
+        return result;
     }
-
-    /**
-     * to be called whenever relevant content changes (to avoid doing this in hashCode which is called a lot). Also:
-     * avoid Objects.hash() to avoid lots of little allocations.
-     */
-    private void recalcHash() {
-        // System.out.println("Recalc pipe spec hash "+((WgGraphics)Gdx.graphics).getFrameId());
-        hash = 1;
-        hash = 31 * hash + (vertexAttributes == null ? 0 : vertexAttributes.hashCode());
-        hash = 31 * hash + (shaderSource == null ? 0 : shaderSource.hashCode());
-        hash = 31 * hash + (isDepthPass ? 1231 : 1237);
-        hash = 31 * hash + (afterDepthPrepass ? 1231 : 1237);
-        hash = 31 * hash + (useDepthTest ? 1231 : 1237);
-        hash = 31 * hash + (noDepthAttachment ? 1231 : 1237);
-        hash = 31 * hash + (topology == null ? 0 : topology.hashCode());
-        hash = 31 * hash + (indexFormat == null ? 0 : indexFormat.hashCode());
-        hash = 31 * hash + (blendingEnabled ? 1231 : 1237);
-        if (blendingEnabled) {
-            hash = 31 * hash + (blendSrcColor == null ? 0 : blendSrcColor.hashCode());
-            hash = 31 * hash + (blendDstColor == null ? 0 : blendDstColor.hashCode());
-            hash = 31 * hash + (blendOpColor == null ? 0 : blendOpColor.hashCode());
-            hash = 31 * hash + (blendSrcAlpha == null ? 0 : blendSrcAlpha.hashCode());
-            hash = 31 * hash + (blendDstAlpha == null ? 0 : blendDstAlpha.hashCode());
-            hash = 31 * hash + (blendOpAlpha == null ? 0 : blendOpAlpha.hashCode());
-        }
-        hash = 31 * hash + numSamples;
-        hash = 31 * hash + (cullMode == null ? 0 : cullMode.hashCode());
-        hash = 31 * hash + (isSkyBox ? 1231 : 1237);
-        hash = 31 * hash + (depthFormat == null ? 0 : depthFormat.hashCode());
-        hash = 31 * hash + numSamples;
-        hash = 31 * hash + maxDirLights;
-        hash = 31 * hash + maxPointLights;
-        hash = 31 * hash + (usePBR ? 1231 : 1237);
-    }
-
-    // note: don't include compiled shader in the hash because this would force new compiles every frame since a spec of
-    // an uncompiled shader <> compiled shader
-
 }

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/RenderPassBuilder.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/RenderPassBuilder.java
@@ -31,6 +31,11 @@ import com.monstrous.gdx.webgpu.graphics.WgTexture;
  */
 public class RenderPassBuilder {
 
+    private static final WGPUTextureView[] scratchViews = new WGPUTextureView[16];
+    private static final WGPUTextureFormat[] scratchFormats = new WGPUTextureFormat[16];
+    // Pre-allocated single-element array to avoid per-call allocation in the single-texture overload
+    private static final WgTexture[] singleTextureArray = new WgTexture[1];
+
     public static WebGPURenderPass create(String name) {
         return create(name, null);
     }
@@ -57,7 +62,8 @@ public class RenderPassBuilder {
     public static WebGPURenderPass create(String name, Color clearColor, boolean clearDepth, int sampleCount,
             RenderPassType passType) {
         WgGraphics gfx = (WgGraphics) Gdx.graphics;
-        return create(name, clearColor, clearDepth, null, gfx.getContext().getDepthTexture(), sampleCount, passType);
+        return create(name, clearColor, clearDepth, (WgTexture[]) null, gfx.getContext().getDepthTexture(), sampleCount,
+                passType);
     }
 
     public static WebGPURenderPass create(String name, Color clearColor, boolean clearDepth, WgTexture colorTexture,
@@ -66,18 +72,27 @@ public class RenderPassBuilder {
                 RenderPassType.COLOR_AND_DEPTH);
     }
 
+    public static WebGPURenderPass create(String name, Color clearColor, boolean clearDepth, WgTexture outTexture,
+            WgTexture depthTexture, int sampleCount, RenderPassType passType) {
+        if (outTexture == null) {
+            return create(name, clearColor, clearDepth, (WgTexture[]) null, depthTexture, sampleCount, passType);
+        }
+        singleTextureArray[0] = outTexture;
+        return create(name, clearColor, clearDepth, singleTextureArray, depthTexture, sampleCount, passType);
+    }
+
     /**
      * Create a render pass
      *
      * @param clearColor background color, null to not clear the screen, e.g. for a UI
      * @param clearDepth clear depth buffer?
-     * @param outTexture output texture, null to render to the screen
+     * @param outTextures output textures, null to render to the screen
      * @param depthTexture output depth texture, can be null
      * @param sampleCount samples per pixel: 1 or 4
-     * @param passType
-     * @return
+     * @param passType render pass type
+     * @return the created WebGPURenderPass
      */
-    public static WebGPURenderPass create(String name, Color clearColor, boolean clearDepth, WgTexture outTexture,
+    public static WebGPURenderPass create(String name, Color clearColor, boolean clearDepth, WgTexture[] outTextures,
             WgTexture depthTexture, int sampleCount, RenderPassType passType) {
         // System.out.println("RenderPassBuilder: create");
         WgGraphics gfx = (WgGraphics) Gdx.graphics;
@@ -88,8 +103,6 @@ public class RenderPassBuilder {
         if (!webgpu.encoder.isValid())
             throw new RuntimeException("Encoder not valid for call of WebGPURenderPass.create()");
 
-        WGPUTextureFormat colorFormat = WGPUTextureFormat.Undefined;
-
         WGPURenderPassDescriptor renderPassDescriptor = WGPURenderPassDescriptor.obtain();
         renderPassDescriptor.setNextInChain(WGPUChainedStruct.NULL);
         renderPassDescriptor.setOcclusionQuerySet(WGPUQuerySet.NULL);
@@ -97,47 +110,71 @@ public class RenderPassBuilder {
 
         WGPUVectorRenderPassColorAttachment colorAttachments = WGPUVectorRenderPassColorAttachment.obtain();
 
+        // determine the targets
+        WGPUTextureView[] targetViews = null;
+        WGPUTextureFormat[] targetFormats = null;
+        int targetCount = 0;
+
+        if (outTextures == null) {
+            targetViews = webgpu.targetViews;
+            targetFormats = webgpu.surfaceFormats;
+            targetCount = targetViews.length;
+        } else {
+            targetCount = outTextures.length;
+            if (targetCount > scratchViews.length) {
+                throw new RuntimeException("Too many render targets: " + targetCount);
+            }
+            for (int i = 0; i < targetCount; i++) {
+                scratchViews[i] = outTextures[i].getTextureView();
+                scratchFormats[i] = outTextures[i].getFormat();
+            }
+            targetViews = scratchViews;
+            targetFormats = scratchFormats;
+        }
+
         if (passType == RenderPassType.COLOR_AND_DEPTH || passType == RenderPassType.COLOR_PASS
                 || passType == RenderPassType.COLOR_PASS_AFTER_DEPTH_PREPASS || passType == RenderPassType.SHADOW_PASS
                 || passType == RenderPassType.NO_DEPTH) {
 
-            WGPURenderPassColorAttachment renderPassColorAttachment = WGPURenderPassColorAttachment.obtain();
-            renderPassColorAttachment.setNextInChain(WGPUChainedStruct.NULL);
-            renderPassColorAttachment.setStoreOp(WGPUStoreOp.Store);
+            for (int i = 0; i < targetCount; i++) {
+                WGPURenderPassColorAttachment renderPassColorAttachment = WGPURenderPassColorAttachment.obtain();
+                renderPassColorAttachment.setNextInChain(WGPUChainedStruct.NULL);
+                renderPassColorAttachment.setStoreOp(WGPUStoreOp.Store);
+                renderPassColorAttachment.setDepthSlice(-1);
 
-            renderPassColorAttachment.setDepthSlice(-1);
+                if (clearColor != null) {
+                    if (!webgpu.hasLinearOutput())
+                        GammaCorrection.fromLinear(clearColor); // inverse gamma correction
+                    renderPassColorAttachment.setLoadOp(WGPULoadOp.Clear);
 
-            if (clearColor != null) {
-                if (!webgpu.hasLinearOutput())
-                    GammaCorrection.fromLinear(clearColor); // inverse gamma correction
-                renderPassColorAttachment.setLoadOp(WGPULoadOp.Clear);
-
-                renderPassColorAttachment.getClearValue().setR(clearColor.r);
-                renderPassColorAttachment.getClearValue().setG(clearColor.g);
-                renderPassColorAttachment.getClearValue().setB(clearColor.b);
-                renderPassColorAttachment.getClearValue().setA(clearColor.a);
-            } else {
-                renderPassColorAttachment.setLoadOp(WGPULoadOp.Load);
-            }
-
-            if (outTexture == null) {
-                if (sampleCount > 1) {
-                    renderPassColorAttachment.setView(webgpu.getMultiSamplingTexture().getTextureView());
-                    renderPassColorAttachment.setResolveTarget(webgpu.getTargetView());
+                    renderPassColorAttachment.getClearValue().setR(clearColor.r);
+                    renderPassColorAttachment.getClearValue().setG(clearColor.g);
+                    renderPassColorAttachment.getClearValue().setB(clearColor.b);
+                    renderPassColorAttachment.getClearValue().setA(clearColor.a);
                 } else {
-                    renderPassColorAttachment.setView(webgpu.getTargetView());
+                    renderPassColorAttachment.setLoadOp(WGPULoadOp.Load);
+                }
+
+                if (sampleCount > 1 && i == 0) { // Keep MSAA logic restricted to first attachment/screen if needed?
+                    // Assuming MSAA only for main screen for now or if supported by logic
+                    // existing logic:
+                    if (outTextures == null) {
+                        renderPassColorAttachment.setView(webgpu.getMultiSamplingTexture().getTextureView());
+                        renderPassColorAttachment.setResolveTarget(webgpu.getTargetViews()[0]);
+                    } else {
+                        // MSAA to texture not fully implemented in this logic block for MRT?
+                        // defaulting to simple logic for custom texture
+                        renderPassColorAttachment.setView(targetViews[i]);
+                        renderPassColorAttachment.setResolveTarget(WGPUTextureView.NULL);
+                    }
+                } else {
+                    renderPassColorAttachment.setView(targetViews[i]);
                     renderPassColorAttachment.setResolveTarget(WGPUTextureView.NULL);
                 }
-                colorFormat = webgpu.getSurfaceFormat();
 
-            } else {
-                renderPassColorAttachment.setView(outTexture.getTextureView());
-                renderPassColorAttachment.setResolveTarget(WGPUTextureView.NULL);
-                colorFormat = outTexture.getFormat();
-                sampleCount = 1;
+                colorAttachments.push_back(renderPassColorAttachment);
             }
 
-            colorAttachments.push_back(renderPassColorAttachment);
         } else {
             sampleCount = 1;
         }
@@ -175,10 +212,18 @@ public class RenderPassBuilder {
         WebGPURenderPass pass = WebGPURenderPass.obtain(); // Reuse render pass
 
         Rectangle view = webgpu.getViewportRectangle(); // todo may change over time
-        WGPUTextureFormat format = webgpu.getSurfaceFormat();
-        pass.begin(webgpu.encoder, renderPassDescriptor, passType, format, depthTexture.getFormat(), sampleCount,
-                outTexture == null ? (int) view.width : outTexture.getWidth(),
-                outTexture == null ? (int) view.height : outTexture.getHeight());
+
+        int width, height;
+        if (outTextures != null && outTextures.length > 0) {
+            width = outTextures[0].getWidth();
+            height = outTextures[0].getHeight();
+        } else {
+            width = (int) view.width;
+            height = (int) view.height;
+        }
+
+        pass.begin(webgpu.encoder, renderPassDescriptor, passType, targetFormats, targetCount, depthTexture.getFormat(),
+                sampleCount, width, height);
 
         pass.setViewport(view.x, view.y, view.width, view.height, 0, 1);
 

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/SkyBox.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/SkyBox.java
@@ -68,7 +68,7 @@ public class SkyBox implements Disposable {
         pipelineSpec.shaderSource = Gdx.files.internal("shaders/skybox.wgsl").readString();
         pipelineSpec.enableDepthTest();
         pipelineSpec.setCullMode(WGPUCullMode.Back);
-        pipelineSpec.colorFormat = webgpu.getSurfaceFormat();
+        pipelineSpec.colorFormats = new WGPUTextureFormat[] {webgpu.getSurfaceFormat()};
         pipelineSpec.depthFormat = WGPUTextureFormat.Depth24Plus;
         pipelineSpec.numSamples = webgpu.getSamples();
         pipelineSpec.isSkyBox = true;

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUPipeline.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPUPipeline.java
@@ -75,32 +75,35 @@ public class WebGPUPipeline implements Disposable {
         pipelineDesc.getPrimitive().setFrontFace(WGPUFrontFace.CCW);
         pipelineDesc.getPrimitive().setCullMode(spec.cullMode);
 
-        if (spec.colorFormat != WGPUTextureFormat.Undefined) { // if there is a color attachment
+        if (spec.colorFormats != null && spec.colorFormats.length > 0) { // if there is a color attachment
             WGPUFragmentState fragmentState = WGPUFragmentState.obtain();
             fragmentState.setNextInChain(WGPUChainedStruct.NULL);
             fragmentState.setModule(shader.getShaderModule());
             fragmentState.setEntryPoint(spec.fragmentShaderEntryPoint);
             fragmentState.setConstants(WGPUVectorConstantEntry.NULL);
 
-            // blending
-            WGPUBlendState blendState = WGPUBlendState.NULL;
-            if (spec.blendingEnabled) {
-                blendState = WGPUBlendState.obtain();
-                blendState.getColor().setSrcFactor(spec.blendSrcColor);
-                blendState.getColor().setDstFactor(spec.blendDstColor);
-                blendState.getColor().setOperation(spec.blendOpColor);
-                blendState.getAlpha().setSrcFactor(spec.blendSrcAlpha);
-                blendState.getAlpha().setDstFactor(spec.blendDstAlpha);
-                blendState.getAlpha().setOperation(spec.blendOpAlpha);
-            }
-
-            WGPUColorTargetState colorTarget = WGPUColorTargetState.obtain();
-            colorTarget.setFormat(spec.colorFormat);
-            colorTarget.setBlend(blendState);
-            colorTarget.setWriteMask(WGPUColorWriteMask.All);
-
             WGPUVectorColorTargetState colorStateTargets = WGPUVectorColorTargetState.obtain();
-            colorStateTargets.push_back(colorTarget);
+
+            for (WGPUTextureFormat format : spec.colorFormats) {
+                // blending
+                WGPUBlendState blendState = WGPUBlendState.NULL;
+                if (spec.blendingEnabled) {
+                    blendState = WGPUBlendState.obtain();
+                    blendState.getColor().setSrcFactor(spec.blendSrcColor);
+                    blendState.getColor().setDstFactor(spec.blendDstColor);
+                    blendState.getColor().setOperation(spec.blendOpColor);
+                    blendState.getAlpha().setSrcFactor(spec.blendSrcAlpha);
+                    blendState.getAlpha().setDstFactor(spec.blendDstAlpha);
+                    blendState.getAlpha().setOperation(spec.blendOpAlpha);
+                }
+
+                WGPUColorTargetState colorTarget = WGPUColorTargetState.obtain();
+                colorTarget.setFormat(format);
+                colorTarget.setBlend(blendState);
+                colorTarget.setWriteMask(WGPUColorWriteMask.All);
+
+                colorStateTargets.push_back(colorTarget);
+            }
             fragmentState.setTargets(colorStateTargets);
 
             pipelineDesc.setFragment(fragmentState);

--- a/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPURenderPass.java
+++ b/gdx-webgpu/src/main/java/com/monstrous/gdx/webgpu/wrappers/WebGPURenderPass.java
@@ -23,10 +23,11 @@ import com.github.xpenatan.webgpu.*;
 public class WebGPURenderPass implements Disposable {
     private WGPURenderPassEncoder renderPass; // handle used by WebGPU
     public RenderPassType type;
-    private WGPUTextureFormat textureFormat;
+    private WGPUTextureFormat[] textureFormats;
     private WGPUTextureFormat depthFormat;
     public int targetWidth, targetHeight;
     private int sampleCount;
+    private final WGPUTextureFormat[] singleFormatArray = new WGPUTextureFormat[1];
 
     private static final Pool<WebGPURenderPass> renderPassPool = new Pool<WebGPURenderPass>() {
         @Override
@@ -57,8 +58,40 @@ public class WebGPURenderPass implements Disposable {
     public void begin(WGPUCommandEncoder encoder, WGPURenderPassDescriptor renderPassDescriptor, RenderPassType type,
             WGPUTextureFormat textureFormat, WGPUTextureFormat depthFormat, int sampleCount, int targetWidth,
             int targetHeight) {
+        singleFormatArray[0] = textureFormat;
+        begin(encoder, renderPassDescriptor, type, singleFormatArray, depthFormat, sampleCount, targetWidth,
+                targetHeight);
+    }
+
+    public void begin(WGPUCommandEncoder encoder, WGPURenderPassDescriptor renderPassDescriptor, RenderPassType type,
+            WGPUTextureFormat[] textureFormats, WGPUTextureFormat depthFormat, int sampleCount, int targetWidth,
+            int targetHeight) {
+        int count = textureFormats == null ? 0 : textureFormats.length;
+        begin(encoder, renderPassDescriptor, type, textureFormats, count, depthFormat, sampleCount, targetWidth,
+                targetHeight);
+    }
+
+    public void begin(WGPUCommandEncoder encoder, WGPURenderPassDescriptor renderPassDescriptor, RenderPassType type,
+            WGPUTextureFormat[] textureFormats, int count, WGPUTextureFormat depthFormat, int sampleCount,
+            int targetWidth, int targetHeight) {
         this.type = type;
-        this.textureFormat = textureFormat;
+
+        // Optimization for single render target (most common case)
+        if (count == 1) {
+            singleFormatArray[0] = textureFormats[0];
+            this.textureFormats = singleFormatArray;
+        } else {
+            // For MRT, valid count > 1
+            // We must copy the array content because the passed array might be a shared scratch buffer
+            if (this.textureFormats == null || this.textureFormats.length != count
+                    || this.textureFormats == singleFormatArray) {
+                this.textureFormats = new WGPUTextureFormat[count];
+            }
+            if (count > 0) {
+                System.arraycopy(textureFormats, 0, this.textureFormats, 0, count);
+            }
+        }
+
         this.depthFormat = depthFormat;
         this.sampleCount = sampleCount;
         this.targetWidth = targetWidth;
@@ -77,7 +110,14 @@ public class WebGPURenderPass implements Disposable {
     }
 
     public WGPUTextureFormat getColorFormat() {
-        return textureFormat;
+        if (textureFormats == null || textureFormats.length == 0)
+            return WGPUTextureFormat.Undefined;
+
+        return textureFormats[0];
+    }
+
+    public WGPUTextureFormat[] getColorFormats() {
+        return textureFormats;
     }
 
     public WGPUTextureFormat getDepthFormat() {

--- a/tests/assets/shaders/modelbatch_mrt.wgsl
+++ b/tests/assets/shaders/modelbatch_mrt.wgsl
@@ -1,0 +1,521 @@
+// basic ModelBatch shader with MRT support (2 targets: color + normal)
+// Copyright 2025 Monstrous Software.
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+// Note this is an uber shader with conditional compilation depending on #define values from the shader prefix
+
+struct DirectionalLight {
+    color: vec4f,
+    direction: vec4f
+}
+
+struct PointLight {
+    color: vec4f,
+    position: vec4f,
+    intensity: f32
+}
+
+struct FrameUniforms {
+    projectionViewTransform: mat4x4f,
+    shadowProjViewTransform: mat4x4f,
+#ifdef MAX_DIR_LIGHTS
+    directionalLights : array<DirectionalLight, MAX_DIR_LIGHTS>,
+#endif
+#ifdef MAX_POINT_LIGHTS
+    pointLights : array<PointLight, MAX_POINT_LIGHTS>,
+#endif
+    ambientLight: vec4f,
+    cameraPosition: vec4f,
+    fogColor: vec4f,
+    numDirectionalLights: f32,
+    numPointLights: f32,
+    shadowPcfOffset: f32,
+    shadowBias: f32,
+    normalMapStrength: f32,
+    numRoughnessLevels: f32,
+};
+
+struct ModelUniforms {
+    modelMatrix: mat4x4f,
+    normalMatrix: mat4x4f,
+    morphWeights: vec4f,
+    morphWeights2: vec4f,
+};
+
+struct MaterialUniforms {
+    diffuseColor: vec4f,
+    shininess: f32,
+    roughnessFactor: f32,
+    metallicFactor: f32,
+};
+
+// frame bindings
+@group(0) @binding(0) var<uniform> uFrame: FrameUniforms;
+#ifdef SHADOW_MAP
+    @group(0) @binding(1) var shadowMap: texture_depth_2d;
+    @group(0) @binding(2) var shadowSampler: sampler_comparison;
+#endif
+#ifdef ENVIRONMENT_MAP
+    @group(0) @binding(3) var cubeMap:          texture_cube<f32>;
+    @group(0) @binding(4) var cubeMapSampler:   sampler;
+#endif
+#ifdef USE_IBL
+    @group(0) @binding(5) var irradianceMap:    texture_cube<f32>;
+    @group(0) @binding(6) var irradianceSampler:       sampler;
+    @group(0) @binding(7) var radianceMap:    texture_cube<f32>;
+    @group(0) @binding(8) var radianceSampler:       sampler;
+    @group(0) @binding(9) var brdfLUT:    texture_2d<f32>;
+    @group(0) @binding(10) var lutSampler:       sampler;
+#endif
+
+// material bindings
+@group(1) @binding(0) var<uniform> material: MaterialUniforms;
+@group(1) @binding(1) var diffuseTexture: texture_2d<f32>;
+@group(1) @binding(2) var diffuseSampler: sampler;
+@group(1) @binding(3) var normalTexture: texture_2d<f32>;
+@group(1) @binding(4) var normalSampler: sampler;
+@group(1) @binding(5) var metallicRoughnessTexture: texture_2d<f32>;
+@group(1) @binding(6) var metallicRoughnessSampler: sampler;
+@group(1) @binding(7) var emissiveTexture: texture_2d<f32>;
+@group(1) @binding(8) var emissiveSampler: sampler;
+
+// renderables
+@group(2) @binding(0) var<storage, read> instances: array<ModelUniforms>;
+
+// Skinning
+#ifdef SKIN
+    @group(3) @binding(0) var<storage, read> jointMatrices: array<mat4x4f>;
+#endif
+
+struct VertexInput {
+    @location(0) position: vec3f,
+#ifdef TEXTURE_COORDINATE
+    @location(1) uv: vec2f,
+#endif
+#ifdef NORMAL
+    @location(2) normal: vec3f,
+#endif
+#ifdef NORMAL_MAP
+    @location(3) tangent: vec3f,
+    @location(4) bitangent: vec3f,
+#endif
+#ifdef COLOR
+    @location(5) color: vec4f,
+#endif
+#ifdef SKIN
+    @location(6) joints: vec4f,
+    @location(7) weights: vec4f,
+#endif
+#ifdef MORPH
+#ifdef MORPH_0
+    @location(8) morph_pos0: vec3f,
+#endif
+#ifdef MORPH_1
+    @location(9) morph_pos1: vec3f,
+#endif
+#ifdef MORPH_2
+    @location(10) morph_pos2: vec3f,
+#endif
+#ifdef MORPH_3
+    @location(11) morph_pos3: vec3f,
+#endif
+#ifdef MORPH_4
+    @location(12) morph_pos4: vec3f,
+#endif
+#ifdef MORPH_5
+    @location(13) morph_pos5: vec3f,
+#endif
+#ifdef MORPH_6
+    @location(14) morph_pos6: vec3f,
+#endif
+#ifdef MORPH_7
+    @location(15) morph_pos7: vec3f,
+#endif
+#endif
+
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(1) uv: vec2f,
+    @location(2) color: vec4f,
+    @location(3) normal: vec3f,
+    @location(4) worldPos : vec3f,
+#ifdef NORMAL_MAP
+    @location(5) tangent: vec3f,
+    @location(6) bitangent: vec3f,
+#endif
+#ifdef FOG
+    @location(7) fogDepth: f32,
+#endif
+#ifdef SHADOW_MAP
+    @location(8)  shadowPos: vec3f,
+#endif
+};
+
+const pi : f32 = 3.14159265359;
+
+@vertex
+fn vs_main(in: VertexInput, @builtin(instance_index) instance: u32) -> VertexOutput {
+   var out: VertexOutput;
+
+   var pos = in.position;
+#ifdef MORPH
+#ifdef MORPH_0
+   pos += instances[instance].morphWeights[0] * in.morph_pos0;
+#endif
+#ifdef MORPH_1
+   pos += instances[instance].morphWeights[1] * in.morph_pos1;
+#endif
+#ifdef MORPH_2
+   pos += instances[instance].morphWeights[2] * in.morph_pos2;
+#endif
+#ifdef MORPH_3
+   pos += instances[instance].morphWeights[3] * in.morph_pos3;
+#endif
+#ifdef MORPH_4
+   pos += instances[instance].morphWeights2[0] * in.morph_pos4;
+#endif
+#ifdef MORPH_5
+   pos += instances[instance].morphWeights2[1] * in.morph_pos5;
+#endif
+#ifdef MORPH_6
+   pos += instances[instance].morphWeights2[2] * in.morph_pos6;
+#endif
+#ifdef MORPH_7
+   pos += instances[instance].morphWeights2[3] * in.morph_pos7;
+#endif
+#endif
+
+   var normal_attr = vec3f(0,1,0);
+#ifdef NORMAL
+   normal_attr = in.normal;
+#endif
+
+#ifdef SKIN
+     // Get relevant 4 bone matrices
+     // joint matrix is already multiplied by inv bind matrix in Node.calculateBoneTransform
+     let joint0 = jointMatrices[u32(in.joints[0])];
+     let joint1 = jointMatrices[u32(in.joints[1])];
+     let joint2 = jointMatrices[u32(in.joints[2])];
+     let joint3 = jointMatrices[u32(in.joints[3])];
+
+     // Compute influence of joint based on weight
+     let skinMatrix =
+       joint0 * in.weights[0] +
+       joint1 * in.weights[1] +
+       joint2 * in.weights[2] +
+       joint3 * in.weights[3];
+
+     // Bone transformed mesh
+   let worldPosition =   instances[instance].modelMatrix * skinMatrix * vec4f(pos, 1.0);
+#else
+   let worldPosition =  instances[instance].modelMatrix * vec4f(pos, 1.0);
+#endif
+
+   out.position =   uFrame.projectionViewTransform * worldPosition;
+   out.worldPos = worldPosition.xyz;
+#ifdef TEXTURE_COORDINATE
+   out.uv = in.uv;
+#else
+   out.uv = vec2f(0);
+#endif
+
+#ifdef COLOR
+   var diffuseColor = in.color;
+#else
+   var diffuseColor = vec4f(1); // default white
+#endif
+   diffuseColor *= material.diffuseColor;
+   out.color = diffuseColor;
+
+#ifdef NORMAL
+   // transform model normal to a world normal
+   let normal = normalize((instances[instance].normalMatrix * vec4f(normal_attr, 0.0)).xyz);
+#else
+   let normal = vec3f(0,1,0);
+#endif
+    out.normal = normal;
+
+#ifdef NORMAL_MAP
+    out.tangent = in.tangent;
+    out.bitangent = in.bitangent;
+#endif
+
+#ifdef FOG
+    let flen:vec3f = uFrame.cameraPosition.xyz - worldPosition.xyz;
+    let fog:f32 = dot(flen, flen) * uFrame.cameraPosition.w;
+    out.fogDepth = min(fog, 1.0);
+#endif
+
+#ifdef SHADOW_MAP
+  // XY is in (-1, 1) space, Z is in (0, 1) space
+  let posFromLight = uFrame.shadowProjViewTransform * worldPosition;
+
+  // Convert XY to (0, 1)
+  // Y is flipped because texture coords are Y-down.
+  out.shadowPos = vec3(
+    posFromLight.xy * vec2(0.5, -0.5) + vec2(0.5),
+    posFromLight.z
+  );
+#endif
+
+   return out;
+}
+
+struct FragmentOutput {
+    @location(0) color : vec4f,
+    @location(1) normal : vec4f,
+};
+
+@fragment
+fn fs_main(in : VertexOutput) -> FragmentOutput {
+#ifdef TEXTURE_COORDINATE
+   var color = in.color * textureSample(diffuseTexture, diffuseSampler, in.uv);
+#else
+   var color = in.color;
+#endif
+
+#ifdef SHADOW_MAP
+    let visibility = getShadowNess(in.shadowPos);
+#else
+    let visibility = 1.0;
+#endif
+
+#ifdef LIGHTING
+    let baseColor = color;
+
+#ifdef NORMAL_MAP
+    let encodedN = textureSample(normalTexture, normalSampler, in.uv).rgb;
+    let localN = encodedN * 2.0 - 1.0;
+    // The TBN matrix converts directions from the local space to the world space
+    let localToWorld = mat3x3f(
+        normalize(in.tangent),
+        normalize(in.bitangent),
+        normalize(in.normal),
+    );
+    let worldN = localToWorld * localN;
+    let normal = mix(in.normal.xyz, worldN, uFrame.normalMapStrength);
+#else // NORMAL_MAP
+    let normal = normalize(in.normal.xyz);
+#endif
+
+    // metallic is coded in the blue channel and roughness in the green channel of the MR texture
+    let mrSample = textureSample(metallicRoughnessTexture, metallicRoughnessSampler, in.uv).rgb;
+
+    let roughness : f32 = mrSample.g * material.roughnessFactor;
+    let metallic : f32 = mrSample.b * material.metallicFactor;
+
+    let shininess : f32 = material.shininess;   // used instead of roughness for non-PBR
+
+    var radiance : vec3f = vec3f(0);    // outgoing radiance (Lo)
+    var specular : vec3f = vec3f(0);
+    let viewVec : vec3f = normalize(uFrame.cameraPosition.xyz - in.worldPos.xyz);
+
+#ifdef USE_IBL
+    let ambient : vec3f = ambientIBL( viewVec, normal, roughness, metallic, baseColor.rgb);
+#else
+    let ambient : vec3f = uFrame.ambientLight.rgb * baseColor.rgb;
+#endif
+
+#ifdef MAX_DIR_LIGHTS
+    // for each directional light
+    // could go to vertex shader but esp. specular lighting will be lower quality
+    let numDirectionalLights = min(uFrame.numDirectionalLights, MAX_DIR_LIGHTS);     // fail-safe
+    if(numDirectionalLights > 0) {
+        for (var i: u32 = 0; i < u32(numDirectionalLights); i++) {
+            let light = uFrame.directionalLights[i];
+
+            let lightVec = -normalize(light.direction.xyz);       // L is unit vector towards light source
+            let NdotL = max(dot(lightVec, normal), 0.0);
+#ifdef PBR
+            if(NdotL > 0.0) {
+                radiance += BRDF(lightVec, viewVec, normal, roughness, metallic, baseColor.rgb) * NdotL *  light.color.rgb;
+            }
+#else
+            radiance += NdotL *  light.color.rgb;
+    #ifdef SPECULAR
+            let halfDotView = max(0.0, dot(normal, normalize(lightVec + viewVec)));
+            specular += NdotL *  light.color.rgb * pow(halfDotView, shininess);
+    #endif
+#endif // PBR
+        }
+    }
+#endif //MAX_DIR_LIGHTS
+
+#ifdef MAX_POINT_LIGHTS
+    // for each point light
+    // note: default libgdx seems to ignore intensity of point lights
+    let numPointLights = min(uFrame.numPointLights, MAX_POINT_LIGHTS); // fail-safe
+    if(numPointLights > 0) {
+        for (var i: u32 = 0; i < u32(numPointLights); i++) {
+            let light = uFrame.pointLights[i];
+
+            var lightVec = light.position.xyz - in.worldPos.xyz;       // L is vector towards light
+            let dist2 : f32 = dot(lightVec,lightVec);
+            lightVec  = normalize(lightVec);
+            let attenuation : f32 = light.intensity/(1.0 + dist2);// attenuation (note this makes an assumption on the world scale)
+            let NdotL : f32 = max(dot(lightVec, normal), 0.0);
+#ifdef PBR
+            if(NdotL > 0.0) {
+                radiance += BRDF(lightVec, viewVec, normal, roughness, metallic, baseColor.rgb) * NdotL *  attenuation * light.color.rgb;
+            }
+#else
+            radiance += NdotL *  attenuation * light.color.rgb;
+#ifdef SPECULAR
+            let halfDotView = max(0.0, dot(normal, normalize(lightVec + viewVec)));
+            specular += NdotL *  attenuation * light.color.rgb * pow(halfDotView, shininess);
+#endif
+#endif // PBR
+        }
+    }
+#endif // MAX_POINT_LIGHTS
+
+#ifdef PBR
+    let litColor = vec4f(ambient + visibility*radiance, 1.0);
+#else
+    let litColor = vec4f( ambient + color.rgb * (visibility * radiance) + visibility*specular, 1.0);
+#endif
+
+    color = litColor;
+
+#ifndef USE_IBL
+    #ifdef ENVIRONMENT_MAP
+        let rdir:vec3f = normalize(reflect(viewVec, normal)*vec3f(-1, -1, 1));
+        var reflection = textureSample(cubeMap, cubeMapSampler, rdir);
+        color = mix(color, reflection, 0.1f);       // todo scale is arbitrary
+    #endif
+#endif
+
+
+#endif // LIGHTING
+
+    let emissiveColor = textureSample(emissiveTexture, emissiveSampler, in.uv).rgb;
+    color = color + vec4f(emissiveColor, 0);
+
+
+#ifdef FOG
+    color = vec4f(mix(color.rgb, uFrame.fogColor.rgb, in.fogDepth), color.a);
+#endif
+
+
+#ifdef GAMMA_CORRECTION
+    let linearColor: vec3f = pow(color.rgb, vec3f(1/2.2));
+    color = vec4f(linearColor, color.a);
+#endif
+
+    var out: FragmentOutput;
+    out.color = color;
+
+    // Output normal
+    // If normal is defined (Lighting block), use it. Else use input normal (interpolated)
+    #ifdef LIGHTING
+       out.normal = vec4f(normal * 0.5 + 0.5, 1.0); // Map -1..1 to 0..1 for visualization
+    #else
+       out.normal = vec4f(normalize(in.normal) * 0.5 + 0.5, 1.0);
+    #endif
+
+    return out;
+};
+
+#ifdef SHADOW_MAP
+// returns value 0..1 for the amount of "sunlight"
+fn getShadowNess( shadowPos:vec3f ) -> f32 {
+
+    // PCF filtering: take 9 samples and use the average value
+    var visibility = 0.0;
+    for( var y = -1; y <= 1; y++){
+        for( var x = -1; x <= 1; x++){
+        let offset = vec2f(vec2(x,y)) * uFrame.shadowPcfOffset;  //oneOverDepthTextureSize
+            // returns 0 or 1
+            visibility += textureSampleCompare(shadowMap, shadowSampler, shadowPos.xy+offset, shadowPos.z - uFrame.shadowBias);
+        }
+    }
+    visibility /= 9.0;  // divide by nr of samples
+    return visibility;
+}
+
+fn getShadowSingleSample( shadowPos:vec3f ) -> f32 {
+    return textureSampleCompare(shadowMap, shadowSampler, shadowPos.xy, shadowPos.z -  uFrame.shadowBias);
+}
+#endif
+
+
+#ifdef PBR
+
+// Normal distribution function
+fn D_GGX(NdotH: f32, roughness: f32) -> f32 {
+    let alpha : f32 = roughness * roughness;
+    let alpha2 : f32 = alpha * alpha;
+    let denom : f32 = (NdotH * NdotH) * (alpha2 - 1.0) + 1.0;
+    return alpha2/(pi * denom * denom);
+}
+
+fn G_SchlickSmith_GGX(NdotL : f32, NdotV : f32, roughness : f32) -> f32 {
+    let r : f32 = (roughness + 1.0);
+    let k : f32 = (r*r)/8.0;
+
+//    let alpha: f32 = roughness * roughness;
+//    let k: f32 = alpha / 2.0;
+
+    let GL : f32 = NdotL / (NdotL * (1.0 - k) + k);
+    let GV : f32 = NdotV / (NdotV * (1.0 - k) + k);
+    return GL * GV;
+}
+
+
+fn F_Schlick(cosTheta : f32, metallic : f32, baseColor : vec3f ) -> vec3f {
+    let F0 : vec3f = mix(vec3(0.04), baseColor, metallic);
+    let F : vec3f = F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+    return F;
+}
+
+fn BRDF( L : vec3f, V:vec3f, N: vec3f, roughness:f32, metallic:f32, baseColor: vec3f) -> vec3f {
+    let H = normalize(V+L);
+    let NdotV : f32 = clamp(dot(N, V), 0.0, 1.0);
+    let NdotL : f32 = clamp(dot(N, L), 0.001, 1.0);
+    let LdotH : f32 = clamp(dot(L, H), 0.0, 1.0);
+    let NdotH : f32 = clamp(dot(N, H), 0.0, 1.0);
+    let HdotV : f32 = clamp(dot(H, V), 0.0, 1.0);
+
+    // calculate terms for microfacet shading model
+    let D :f32      = D_GGX(NdotH, roughness);
+    let G :f32      = G_SchlickSmith_GGX(NdotL, NdotV, roughness);
+    let F :vec3f    = F_Schlick(HdotV, metallic, baseColor);
+
+    let kS = F;
+    let kD = (vec3f(1.0) - kS) * (1.0 - metallic);
+
+    let specular : vec3f = D * F * G / (4.0 * max(NdotL, 0.0001) * max(NdotV, 0.0001));
+
+    let diffuse : vec3f = kD * baseColor / pi;
+
+    let Lo : vec3f = diffuse + specular;
+    return Lo;
+}
+
+#ifdef USE_IBL
+fn ambientIBL( V:vec3f, N: vec3f, roughness:f32, metallic:f32, baseColor: vec3f) -> vec3f {
+
+    let NdotV : f32 = clamp(dot(N, V), 0.0, 1.0);
+    let F :vec3f    =  F_Schlick(NdotV, metallic, baseColor);
+
+    // kS = F, kD = 1 - kS;
+    let kD = (vec3f(1.0) - F)*(1.0 - metallic);
+
+    let lightSample:vec3f = normalize(N * vec3f(1, 1, -1));   // flip Z
+    let irradiance:vec3f = textureSample(irradianceMap, irradianceSampler, lightSample).rgb;
+    let diffuse:vec3f    = irradiance * baseColor.rgb;
+
+    let maxReflectionLOD:f32 = f32(uFrame.numRoughnessLevels);
+    let R:vec3f = reflect(-V, N)* vec3f(-1, 1, 1); // flip X
+    let prefilteredColor:vec3f = textureSampleLevel(radianceMap, radianceSampler, R, roughness * maxReflectionLOD).rgb;
+    let envBRDF = textureSample(brdfLUT, lutSampler, vec2(NdotV, roughness)).rg;
+    let specular: vec3f = prefilteredColor * (F * envBRDF.x + envBRDF.y);
+    let ambient:vec3f    = (kD * diffuse) + specular;
+
+    return vec3f(ambient);
+}
+#endif // USE_IBL
+#endif // PBR
+

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/MRTTest2D.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/MRTTest2D.java
@@ -1,0 +1,125 @@
+package com.monstrous.gdx.tests.webgpu;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.github.xpenatan.webgpu.WGPUTextureFormat;
+import com.monstrous.gdx.tests.webgpu.utils.GdxTest;
+import com.monstrous.gdx.webgpu.application.WgGraphics;
+import com.monstrous.gdx.webgpu.graphics.WgShaderProgram;
+import com.monstrous.gdx.webgpu.graphics.WgTexture;
+import com.monstrous.gdx.webgpu.graphics.g2d.WgBitmapFont;
+import com.monstrous.gdx.webgpu.graphics.g2d.WgSpriteBatch;
+import com.monstrous.gdx.webgpu.graphics.utils.WgFrameBuffer;
+import com.monstrous.gdx.webgpu.graphics.utils.WgScreenUtils;
+
+/**
+ * Tests Multiple Render Targets (MRT) by rendering to a FrameBuffer with two color attachments.
+ */
+public class MRTTest2D extends GdxTest {
+
+    WgSpriteBatch batch;
+    WgSpriteBatch mrtBatch;
+    WgBitmapFont font;
+    WgGraphics gfx;
+    WgFrameBuffer mrtFbo;
+    Texture texture;
+    WgShaderProgram mrtShader;
+
+    public void create() {
+        gfx = (WgGraphics) Gdx.graphics;
+        batch = new WgSpriteBatch();
+        font = new WgBitmapFont(); // default font
+
+        // Create a custom shader that outputs to two targets
+        String shaderSource = getMRTShaderSource();
+        mrtShader = new WgShaderProgram("mrt_shader", shaderSource, "");
+
+        // Create a separate batch for rendering into the MRT FBO using the custom shader
+        mrtBatch = new WgSpriteBatch(1000, mrtShader);
+
+        texture = new WgTexture(Gdx.files.internal("data/badlogic.jpg"));
+
+        // Create FrameBuffer with 2 RGBA8Unorm attachments
+        WGPUTextureFormat[] formats = new WGPUTextureFormat[] {WGPUTextureFormat.RGBA8Unorm,
+                WGPUTextureFormat.RGBA8Unorm};
+        mrtFbo = new WgFrameBuffer(formats, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
+    }
+
+    public void render() {
+        // 1. Render to MRT FrameBuffer
+        mrtFbo.begin();
+        {
+            // Clear both attachments to black/transparent
+            // WgScreenUtils.clear clears the FIRST attachment primarily,
+            // but RenderPassBuilder handles clearing logic for attachments if LoadOp is Clear.
+            // For simplicity, we assume clear works or we just draw over it
+            WgScreenUtils.clear(Color.BLACK, true);
+
+            mrtBatch.begin();
+            mrtBatch.draw(texture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+            mrtBatch.end();
+        }
+        mrtFbo.end();
+
+        // 2. Render FBO attachments to screen
+        WgScreenUtils.clear(Color.DARK_GRAY, true);
+
+        batch.begin();
+
+        float w = Gdx.graphics.getWidth() / 2f;
+        float h = Gdx.graphics.getHeight() / 2f;
+
+        // Draw Attachment 0 (Should be Red channel)
+        batch.draw(mrtFbo.getColorBufferTexture(0), 0, h, w, h);
+        font.draw(batch, "Target 0 (Red)", 10, h + 20);
+
+        // Draw Attachment 1 (Should be Green channel)
+        batch.draw(mrtFbo.getColorBufferTexture(1), w, h, w, h);
+        font.draw(batch, "Target 1 (Green)", w + 10, h + 20);
+
+        // Draw Original for reference
+        batch.draw(texture, w / 2, 0, w, h);
+        font.draw(batch, "Original", w / 2 + 10, 20);
+
+        batch.end();
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+        mrtBatch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+        // recreate FBO if needed or just handle scaling
+    }
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+        mrtBatch.dispose();
+        font.dispose();
+        texture.dispose();
+        mrtFbo.dispose();
+        mrtShader.dispose();
+    }
+
+    private String getMRTShaderSource() {
+        return "struct Uniforms {\n" + "    projectionMatrix: mat4x4f,\n" + "};\n" + "\n"
+                + "@group(0) @binding(0) var<uniform> uniforms: Uniforms;\n"
+                + "@group(0) @binding(1) var texture: texture_2d<f32>;\n"
+                + "@group(0) @binding(2) var textureSampler: sampler;\n" + "\n" + "\n" + "struct VertexInput {\n"
+                + "    @location(0) position: vec2f,\n" + "    @location(1) uv: vec2f,\n"
+                + "    @location(5) color: vec4f,\n" + "};\n" + "\n" + "struct VertexOutput {\n"
+                + "    @builtin(position) position: vec4f,\n" + "    @location(0) uv : vec2f,\n"
+                + "    @location(1) color: vec4f,\n" + "};\n" + "\n" + "\n" + "@vertex\n"
+                + "fn vs_main(in: VertexInput) -> VertexOutput {\n" + "   var out: VertexOutput;\n" + "\n"
+                + "   var pos =  uniforms.projectionMatrix * vec4f(in.position, 0.0, 1.0);\n"
+                + "   out.position = pos;\n" + "   out.uv = in.uv;\n" + "\n" + "   let color:vec4f = in.color;\n"
+                + "   out.color = color;\n" + "\n" + "   return out;\n" + "}\n" + "\n" + "struct FragmentOutput {\n"
+                + "    @location(0) color0 : vec4f,\n" + "    @location(1) color1 : vec4f,\n" + "};\n" + "\n"
+                + "@fragment\n" + "fn fs_main(in : VertexOutput) -> FragmentOutput {\n" + "\n"
+                + "    var out: FragmentOutput;\n"
+                + "    var color = in.color * textureSample(texture, textureSampler, in.uv);\n"
+                + "    out.color0 = vec4f(color.r, 0.0, 0.0, color.a);\n"
+                + "    out.color1 = vec4f(0.0, color.g, 0.0, color.a);\n" + "    return out;\n" + "}";
+    }
+}

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/MRTTest3D.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/MRTTest3D.java
@@ -1,0 +1,143 @@
+package com.monstrous.gdx.tests.webgpu;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.graphics.g3d.Environment;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.environment.DirectionalLight;
+import com.badlogic.gdx.graphics.g3d.utils.AnimationController;
+import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
+import com.github.xpenatan.webgpu.WGPUTextureFormat;
+import com.monstrous.gdx.tests.webgpu.utils.GdxTest;
+import com.monstrous.gdx.webgpu.graphics.g2d.WgBitmapFont;
+import com.monstrous.gdx.webgpu.graphics.g2d.WgSpriteBatch;
+import com.monstrous.gdx.webgpu.graphics.g3d.WgModelBatch;
+import com.monstrous.gdx.webgpu.graphics.g3d.WgModelInstance;
+import com.monstrous.gdx.webgpu.graphics.g3d.loaders.WgGLTFModelLoader;
+import com.monstrous.gdx.webgpu.graphics.g3d.loaders.WgModelLoader;
+import com.monstrous.gdx.webgpu.graphics.g3d.shaders.WgDefaultShaderProvider;
+import com.monstrous.gdx.webgpu.graphics.utils.WgFrameBuffer;
+import com.monstrous.gdx.webgpu.graphics.utils.WgScreenUtils;
+
+/**
+ * Multiple Render Targets (MRT) test with 3D model. Renders a GLTF model with animation into a FrameBuffer with Color
+ * and Normal attachments.
+ */
+public class MRTTest3D extends GdxTest {
+
+    WgModelBatch modelBatch;
+    PerspectiveCamera cam;
+    CameraInputController controller;
+    WgSpriteBatch batch;
+    WgBitmapFont font;
+    Model model;
+    WgModelInstance instance;
+    Environment environment;
+    WgFrameBuffer mrtFbo;
+    AnimationController animationController;
+
+    private static final int WIDTH = 1280;
+    private static final int HEIGHT = 720;
+
+    public void create() {
+        // Setup MRT FrameBuffer (Color + Normal)
+        WGPUTextureFormat[] formats = new WGPUTextureFormat[] {WGPUTextureFormat.BGRA8Unorm, // Color (use BGRA for
+                                                                                             // compatibility with many
+                                                                                             // swapchains/defaults)
+                WGPUTextureFormat.RGBA16Float // Normal (high precision)
+        };
+        mrtFbo = new WgFrameBuffer(formats, WIDTH, HEIGHT, true);
+
+        // Setup ModelBatch with custom MRT Shader via high-level Config
+        WgModelBatch.Config config = new WgModelBatch.Config();
+        config.numBones = 100; // Increase bone limit for SillyDancing model (65 bones)
+        config.shaderSource = Gdx.files.internal("shaders/modelbatch_mrt.wgsl").readString();
+
+        modelBatch = new WgModelBatch(new WgDefaultShaderProvider(config));
+
+        cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        cam.position.set(2, 2, 3f);
+        cam.lookAt(0, 1, 0);
+        cam.near = 0.1f;
+        cam.far = 100f;
+
+        controller = new CameraInputController(cam);
+        Gdx.input.setInputProcessor(controller);
+
+        batch = new WgSpriteBatch();
+        font = new WgBitmapFont();
+
+        // Load Model (SillyDancing)
+        WgModelLoader.ModelParameters params = new WgModelLoader.ModelParameters();
+        params.textureParameter.genMipMaps = true;
+        model = new WgGLTFModelLoader().loadModel(Gdx.files.internal("data/g3d/gltf/SillyDancing/SillyDancing.gltf"),
+                params);
+        instance = new WgModelInstance(model);
+
+        animationController = new AnimationController(instance);
+        if (instance.animations.size > 0) {
+            animationController.setAnimation(instance.animations.get(0).id, -1);
+        }
+
+        environment = new Environment();
+        environment.set(new ColorAttribute(ColorAttribute.AmbientLight, 0.4f, 0.4f, 0.4f, 1f));
+        environment.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -1f, -0.8f, -0.2f));
+    }
+
+    public void render() {
+        float delta = Gdx.graphics.getDeltaTime();
+        animationController.update(delta);
+        cam.update();
+
+        // 1. Render to MRT FBO
+        mrtFbo.begin();
+        {
+            // Clear attachments. Note: built-in clear might only clear color/depth.
+            // We can rely on render pass load op = Clear if set up correctly,
+            // or simply use WgScreenUtils.clear which clears the currently bound target(s).
+            WgScreenUtils.clear(Color.DARK_GRAY, true);
+
+            modelBatch.begin(cam);
+            modelBatch.render(instance, environment);
+            modelBatch.end();
+        }
+        mrtFbo.end();
+
+        // 2. Render results to screen
+        WgScreenUtils.clear(Color.BLACK, true);
+
+        batch.begin();
+        float w = Gdx.graphics.getWidth() / 2f;
+        float h = Gdx.graphics.getHeight();
+
+        // Draw Color Attachment
+        batch.draw(mrtFbo.getColorBufferTexture(0), 0, 0, w, h);
+        font.draw(batch, "Color Output", 20, 40);
+
+        // Draw Normal Attachment
+        batch.draw(mrtFbo.getColorBufferTexture(1), w, 0, w, h);
+        font.draw(batch, "Normal Output", w + 20, 40);
+
+        batch.end();
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        cam.viewportWidth = width;
+        cam.viewportHeight = height;
+        cam.update();
+        batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+    }
+
+    @Override
+    public void dispose() {
+        modelBatch.dispose();
+        batch.dispose();
+        font.dispose();
+        model.dispose();
+        mrtFbo.dispose();
+    }
+
+}

--- a/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/WebGPUTests.java
+++ b/tests/gdx-webgpu-tests/src/com/monstrous/gdx/tests/webgpu/WebGPUTests.java
@@ -66,7 +66,8 @@ public class WebGPUTests {
                     SkyBoxTest.class, DuckField.class, IBL_Sliders.class, IBL_Spheres.class, IBL_GenerateOutdoor.class,
                     GLTFAnimation.class, GLTFMorphAnimation.class, GLTFSkinning.class, Scene2dTestScrollPane.class,
                     GLTFSkinningMultiple.class, GLTFSkinningShadow.class, ParticleControllerTest.class,
-                    Particles3D.class, Particles3DSnow.class, Particles3DmodelInstance.class, ScreenReaderTest.class
+                    Particles3D.class, Particles3DSnow.class, Particles3DmodelInstance.class, ScreenReaderTest.class,
+                    MRTTest2D.class, MRTTest3D.class
 
             // @on
 


### PR DESCRIPTION
This PR introduces Multi-Render Target (MRT) support.

**MRT (Multiple Render Targets)** makes it possible for a fragment shader to output to multiple render targets at once, which allows implementing more advanced post-processing and effects in a single rendering pass.

Because this feature touches many areas of the rendering pipeline, it carries a higher risk of regressions.  
All current tests are passing.

<img width="637" height="531" alt="image" src="https://github.com/user-attachments/assets/4dd02cca-30ca-461c-ada0-004d659d69b7" />
<img width="642" height="523" alt="image" src="https://github.com/user-attachments/assets/45eee040-2736-489e-8f34-9f1e3022d74c" />
